### PR TITLE
Add respository information to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
   },
   "author": "",
   "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pelias/interpolation.git"
+  },
   "dependencies": {
     "cli-table2": "^0.2.0",
     "csv-parse": "^1.1.7",


### PR DESCRIPTION
This prevents a warning when running `npm install`