### PR TITLE
Dockerize builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,17 @@
 FROM ubuntu:16.04
 ENV DEBIAN_FRONTEND noninteractive
 
+# --- locale ---
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
 # --- libpostal ---
 
 # dependencies
 RUN apt-get update && apt-get install -y \
-    curl libsnappy-dev autoconf automake libtool pkg-config git
+    curl libsnappy-dev autoconf automake libtool pkg-config git time
 
 # clone
 RUN mkdir -p /usr/src/repos

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,17 @@ RUN git clone https://github.com/isaacs/nave.git
 WORKDIR /usr/src/repos/nave
 RUN ./nave.sh usemain 4.4.7
 
+# --- pbf2json ---
+
+# clone
+RUN mkdir -p /usr/src/repos
+WORKDIR /usr/src/repos
+RUN git clone https://github.com/pelias/pbf2json.git
+
+# install
+RUN chmod +x /usr/src/repos/pbf2json/build/pbf2json.linux-x64
+ENV PBF2JSON_BIN /usr/src/repos/pbf2json/build/pbf2json.linux-x64
+
 # --- node app ---
 
 # dependencies
@@ -58,7 +69,7 @@ EXPOSE 3000
 # attach data directory
 VOLUME "/data"
 
-# run server
+# set entry point
 WORKDIR /usr/src/repos/interpolation
 ENTRYPOINT [ "./interpolate" ];
 CMD [ "server", "/data/address.db", "/data/street.db" ]

--- a/interpolate
+++ b/interpolate
@@ -17,7 +17,7 @@ cat <<EOM
    extract [address_db] [street_db] [lat] [lon] [street_name]                extract street address data for debugging purposes
    server [address_db] [street_db]                                           start a web server
 
-   import                                                                    run the import script
+   build                                                                     run the import script
 EOM
 }
 
@@ -37,19 +37,20 @@ case "$1" in
   env_vars=( 'BUILDDIR' 'POLYLINE_FILE' 'OAPATH' 'PBF2JSON_BIN' 'PBF2JSON_FILE' )
   for var_name in "${env_vars[@]}"; do
     [ -z "${!var_name}" ] && echo "env var $var_name required" && exit 1;
+    export "${var_name}"; # export so child scripts can pick them up
   done
 
   # run polyline importer
-  source $BASEDIR/script/import.sh;
+  /bin/bash $BASEDIR/script/import.sh;
 
   # run openaddresses conflation
-  source $BASEDIR/script/conflate_oa.sh;
+  /bin/bash $BASEDIR/script/conflate_oa.sh;
 
   # run openstreetmap conflation
-  source $BASEDIR/script/conflate_osm.sh;
+  /bin/bash $BASEDIR/script/conflate_osm.sh;
 
   # run vertex interpolation
-  source $BASEDIR/script/vertices.sh;
+  /bin/bash $BASEDIR/script/vertices.sh;
   ;;
 *)
   help;;

--- a/interpolate
+++ b/interpolate
@@ -1,42 +1,64 @@
-#!/usr/bin/env node
+#!/bin/bash
+set -e;
+export LC_ALL=en_US.UTF-8;
+BASEDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd );
 
-// available commands
-var commands = {
-  polyline: './cmd/polyline',
-  oa: './cmd/oa',
-  osm: './cmd/osm',
-  vertices: './cmd/vertices',
-  search: './cmd/search',
-  server: './cmd/server',
-};
+function help(){
+cat <<EOM
+  Usage: interpolate [command] [options]
+  Note: you will need to pipe data in to the import/conflate commands
 
-// remove cmd name from args
-var cmd = process.argv[2];
-process.argv.splice(2, 1);
+   help                                                                      output usage information
+   search [address_db] [street_db] [lat] [lon] [house_number] [street_name]  search database for specified housenumber + street
+   polyline [street_db]                                                      import polyline data in to [street_db]
+   oa [address_db] [street_db]                                               conflate oa csv file in to [address_db] using [street_db]
+   osm [address_db] [street_db]                                              conflate osm file in to [address_db] using [street_db]
+   vertices [address_db] [street_db]                                         compute fractional house numbers for line vertices
+   extract [address_db] [street_db] [lat] [lon] [street_name]                extract street address data for debugging purposes
+   server [address_db] [street_db]                                           start a web server
 
-// run command
-if( cmd in commands ){
-  require( commands[cmd] );
+   import                                                                    run the import script
+EOM
 }
 
-// invalid command
-else {
-  console.error( '\n' + helpText()  + '\n' );
-  process.exit(1);
-}
+# cli runner
+case "$1" in
+'help') help;;
+'search') node "$DIR/cmd/search" $2 $3 $4 $5 $6 $7;;
+'polyline') node "$DIR/cmd/polyline" $2;;
+'oa') node "$DIR/cmd/oa" $2 $3;;
+'osm') node "$DIR/cmd/osm" $2 $3;;
+'vertices') node "$DIR/cmd/vertices" $2 $3;;
+'extract') node "$DIR/cmd/extract" $2 $3 $4 $5 $6;;
+'server') node "$DIR/cmd/server" $2 $3;;
+'build')
 
-function helpText(){
-  return [
-    'Usage: interpolate [command] [options]',
-    'Note: you will need to pipe data in to the import/conflate commands',
-    '',
-    ' help                                                                      output usage information',
-    ' search [address_db] [street_db] [lat] [lon] [house_number] [street_name]  search database for specified housenumber + street',
-    ' polyline [street_db]                                                      import polyline data in to [street_db]',
-    ' oa [address_db] [street_db]                                               conflate oa csv file in to [address_db] using [street_db]',
-    ' osm [address_db] [street_db]                                              conflate osm file in to [address_db] using [street_db]',
-    ' vertices [address_db] [street_db]                                         compute fractional house numbers for line vertices',
-    ' extract [address_db] [street_db] [lat] [lon] [street_name]                extract street address data for debugging purposes',
-    ' server [address_db] [street_db]                                           start a web server'
-  ].join('\n');
-}
+  # validate all ENV vars are explicitly set
+  env_vars=( 'BUILDDIR' 'POLYLINE_FILE' 'OAPATH' 'PBF2JSON_BIN' 'PBF2JSON_FILE' )
+  for var_name in "${env_vars[@]}"; do
+    [ -z "${!var_name}" ] && echo "env var $var_name required" && exit 1;
+  done
+
+  # run polyline importer
+  source $BASEDIR/script/import.sh;
+
+  # run openaddresses conflation
+  source $BASEDIR/script/conflate_oa.sh;
+
+  # run openstreetmap conflation
+  source $BASEDIR/script/conflate_osm.sh;
+
+  # run vertex interpolation
+  source $BASEDIR/script/vertices.sh;
+  ;;
+*)
+  help;;
+esac
+
+# build example
+# BUILDDIR=/tmp/tempbuild \
+# POLYLINE_FILE=/data/polyline/berlin.polylines \
+# OAPATH=/data/oa/de \
+# PBF2JSON_BIN=/var/www/pelias/pbf2json/build/pbf2json.linux-x64 \
+# PBF2JSON_FILE=/data/extract/berlin-latest.osm.pbf \
+# ./interpolate build

--- a/readme.md
+++ b/readme.md
@@ -264,6 +264,39 @@ you can run any command supported by `./interpolate` via the docker container, s
 cat /data/new_zealand.polylines | docker run -i -v /data:/data pelias/interpolation polyline /data/nz.db
 ```
 
+### running a build in the docker container
+
+the build scripts are configurable via environment variables, you will need to download your data before running the build command.
+
+```bash
+# prepare a build directory and a data directory to hold the newly created database files
+mkdir -p /tmp/data/berlin
+
+# download polyline street data
+curl -s http://missinglink.files.s3.amazonaws.com/berlin.gz | gzip -d > /tmp/data/berlin.0sv
+
+# download and extract openaddresses data
+curl -s https://s3.amazonaws.com/data.openaddresses.io/runs/142027/de/berlin.zip > /tmp/data/berlin.zip
+unzip /tmp/data/berlin.zip -d /tmp/data
+
+# download openstreetmap data
+curl -s https://s3.amazonaws.com/metro-extracts.mapzen.com/berlin_germany.osm.pbf > /tmp/data/berlin.osm.pbf
+```
+
+we will mount `/tmp/data` on the local machine as `/data` inside the container, so be careful to set paths as they appear inside the container.
+
+```bash
+docker run -i \ # run interactively (optionally daemonize with -d)
+  -v /tmp/data:/data \ # volume mapping
+  -e 'BUILDDIR=/data/berlin' \ # location where the db files will be created
+  -e 'POLYLINE_FILE=/data/berlin.0sv' \ # location of the polyline data
+  -e 'OAPATH=/data/de' \ # location of the openaddresses data
+  -e 'PBF2JSON_FILE=/data/berlin.osm.pbf' \ # location of the openstreetmap data
+  pelias/interpolation build
+```
+
+once completed you should find the newly created `street.db` and `address.db` files in `/tmp/data/berlin` on your local machine.
+
 # development
 
 ### install dependencies


### PR DESCRIPTION
This PR refactors the Docker entry point `./interpolate` so that it can run shell script as well as node scripts.

added documentation on how to run a build using the Docker container, see `readme.md`