### PR TITLE
bin: pass SIGTERM signal to child processes

### DIFF
--- a/interpolate
+++ b/interpolate
@@ -21,16 +21,23 @@ cat <<EOM
 EOM
 }
 
+# trap SIGTERM and propogate to child process
+_term() {
+  echo "Caught SIGTERM signal!"
+  kill -TERM "$child" 2>/dev/null
+}
+trap _term SIGTERM
+
 # cli runner
 case "$1" in
 'help') help;;
-'search') node "$BASEDIR/cmd/search" $2 $3 $4 $5 $6 $7;;
-'polyline') node "$BASEDIR/cmd/polyline" $2;;
-'oa') node "$BASEDIR/cmd/oa" $2 $3;;
-'osm') node "$BASEDIR/cmd/osm" $2 $3;;
-'vertices') node "$BASEDIR/cmd/vertices" $2 $3;;
-'extract') node "$BASEDIR/cmd/extract" $2 $3 $4 $5 $6;;
-'server') node "$BASEDIR/cmd/server" $2 $3;;
+'search') node "$BASEDIR/cmd/search" "$2" "$3" "$4" "$5" "$6" "$7" &;;
+'polyline') node "$BASEDIR/cmd/polyline" "$2" &;;
+'oa') node "$BASEDIR/cmd/oa" "$2" "$3" &;;
+'osm') node "$BASEDIR/cmd/osm" "$2" "$3" &;;
+'vertices') node "$BASEDIR/cmd/vertices" "$2" "$3" &;;
+'extract') node "$BASEDIR/cmd/extract" "$2" "$3" "$4" "$5" "$6" &;;
+'server') node "$BASEDIR/cmd/server" "$2" "$3" &;;
 'build')
 
   # validate all ENV vars are explicitly set
@@ -41,20 +48,27 @@ case "$1" in
   done
 
   # run polyline importer
-  /bin/bash $BASEDIR/script/import.sh;
+  /bin/bash $BASEDIR/script/import.sh &
+  child=$!; wait "$child";
 
   # run openaddresses conflation
-  /bin/bash $BASEDIR/script/conflate_oa.sh;
+  /bin/bash $BASEDIR/script/conflate_oa.sh &
+  child=$!; wait "$child";
 
   # run openstreetmap conflation
-  /bin/bash $BASEDIR/script/conflate_osm.sh;
+  /bin/bash $BASEDIR/script/conflate_osm.sh &
+  child=$!; wait "$child";
 
   # run vertex interpolation
-  /bin/bash $BASEDIR/script/vertices.sh;
+  /bin/bash $BASEDIR/script/vertices.sh &
   ;;
 *)
   help;;
 esac
+
+# wait for child process(es) to exit before exiting
+child=$!
+wait "$child"
 
 # build example
 # BUILDDIR=/tmp/tempbuild \


### PR DESCRIPTION
without this code when the parent bash script dies it leaves the child processes running.

this is bad when using `upstart` or when running a build as child scripts keep running well after the bash script has died.