### PR TITLE
Setup travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+sudo: false
+language: node_js
+cache:
+  directories:
+    - node_modules
+notifications:
+  email: false
+node_js:
+  - 4
+  - 6
+matrix:
+    fast_finish: true
+    allow_failures:
+env:
+  global:
+    - CXX=g++-4.8
+script: "npm run travis"
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
+before_install:
+  - npm i -g npm@^2.0.0
+before_script:
+  - npm prune
+after_success:
+  - npm run semantic-release

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "index.js",
   "scripts": {
-    "test": "npm run units; npm run funcs;",
+    "test": "npm run units",
     "funcs": "node test/_func.js | tap-spec",
     "units": "node test/_unit.js | tap-spec",
     "lint": "jshint .",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "main": "index.js",
   "scripts": {
     "test": "npm run units",
+    "travis": "npm run units && npm run funcs",
     "funcs": "node test/_func.js | tap-spec",
     "units": "node test/_unit.js | tap-spec",
     "lint": "jshint .",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "tape": "^4.6.2"
   },
   "pre-commit": [
-    "lint"
+    "lint",
+    "test"
   ]
 }


### PR DESCRIPTION
This sets up our standard TravisCI file to run the tests against Node 4 and 6. It also sets up precommit-hook to run the unit tests before committing :)

After this is merged, Greenkeeper will be much nicer to this repo as it won't _always_ complain that the tests fail for every new package version released.