### PR TITLE
Use @mapbox/polyline package

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "csv-parse": "^1.1.7",
     "express": "^4.14.0",
     "node-postal": "^0.3.0",
-    "polyline": "^0.2.0",
+    "@mapbox/polyline": "^0.2.0",
     "quadtree": "^1.1.3",
     "require-dir": "^0.3.1",
     "serve-index": "^1.8.0",


### PR DESCRIPTION
This removes a deprecation warning when running `npm i` and allows us to
get updates to the polyline package in the future.