### PR TITLE
Improve libpostal mocking

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "cli-table2": "^0.2.0",
     "csv-parse": "^1.2.0",
     "express": "^4.14.0",
-    "node-postal": "^0.3.0",
+    "node-postal": "^1.0.0",
     "@mapbox/polyline": "^0.2.0",
     "quadtree": "^1.1.3",
     "require-dir": "^0.3.1",

--- a/readme.md
+++ b/readme.md
@@ -423,3 +423,11 @@ cat test/functional/potsdamerplatz/reports/preview.geojson | geojsonio
 once you have completed your tests and committed the files, your preview files will be visible to everyone via github.
 
 the `./reports` directory also contains the `stdio` files from each command that was executed and a list of records which failed to conflate. these files are ignored by `.gitignore` so they don't show up on github.
+
+### Updating the mock libpostal responses
+
+Because of the high memory and disk space requirements of libpostal, tests can be run using a list of known libpostal responses, rather than calling libpostal itself.
+
+These mock responses are stored in `test/lib/mock_libpostal_responses.json`. They will be used by the tests as long as the `MOCK_LIBPOSTAL` environment variable is set.
+
+When libpostal itself changes, these mock responses need to be updated. Running the tests with `SEED_MOCK_LIBPOSTAL` set as well will cause the mock library to actually call libpostal itself, and update `mock_libpostal_responses.json`.

--- a/test/functional/potsdamerplatz/run.js
+++ b/test/functional/potsdamerplatz/run.js
@@ -59,7 +59,7 @@ module.exports.functional.street_counts = function(test) {
 
     // count names table
     var names = sqlite3.count( paths.db.street, 'names' );
-    t.equal(names, 454, 'count(names)');
+    t.equal(names, 487, 'count(names)');
 
     // count rtree table
     var rtree = sqlite3.count( paths.db.street, 'rtree' );

--- a/test/lib/analyze.js
+++ b/test/lib/analyze.js
@@ -11,7 +11,7 @@ module.exports.analyze.street = function(test) {
   });
   test('street: remove ordinals', function(t) {
     var perms = analyze.street('West 26th st');
-    t.deepEqual(perms, ['west 26 street', 'west 26 saint', 'west 26']);
+    t.deepEqual(perms, ['west 26 street', 'west 26 saint']);
     t.end();
   });
   test('street: always returns array', function(t) {

--- a/test/lib/analyze.js
+++ b/test/lib/analyze.js
@@ -6,12 +6,12 @@ module.exports.analyze = {};
 module.exports.analyze.street = function(test) {
   test('street: synonym expansions', function(t) {
     var perms = analyze.street('grolmanstraße');
-    t.deepEqual(perms, ['grolmanstrasse', 'grolman strasse']);
+    t.deepEqual(perms, ['grolmanstraße', 'grolman straße']);
     t.end();
   });
   test('street: remove ordinals', function(t) {
     var perms = analyze.street('West 26th st');
-    t.deepEqual(perms, ['west 26 street', 'west 26 saint']);
+    t.deepEqual(perms, ['west 26 street', 'west 26 saint', 'west 26']);
     t.end();
   });
   test('street: always returns array', function(t) {

--- a/test/lib/mock_libpostal.js
+++ b/test/lib/mock_libpostal.js
@@ -6,9 +6,10 @@ const fs = require('fs');
 // the real libpostal module, if needed will be loaded here
 let real_libpostal;
 
-/* Actually use the real libpostal to seed all the responses.
- * Changing this to true should not be committed. */
-const use_real_libpostal = false;
+/* When `SEED_MOCK_LIBPOSTAL is set, this library will actually
+ * call through to the real libpostal and record the response.
+ * In this way the mock responses can be kept up to date as libpostal changes */
+const use_real_libpostal = process.env.SEED_MOCK_LIBPOSTAL !== undefined;
 
 // put all desired responses from libpostal here
 let mock_responses = require('../../test/lib/mock_libpostal_responses');

--- a/test/lib/mock_libpostal_responses.json
+++ b/test/lib/mock_libpostal_responses.json
@@ -2,12 +2,32 @@
   "glasgow street": [
     "glasgow street"
   ],
-  "grolmanstraße": [
-    "grolmanstrasse",
-    "grolman strasse"
+  "grolmanstrasse": [
+    "grolmanstraße",
+    "grolman straße"
   ],
   "west 26th street": [
     "west 26th street"
+  ],
+  "rigaer strasse": [
+    "rigaer strasse"
+  ],
+  "markgrafenstrasse": [
+    "markgrafenstraße",
+    "markgrafen straße"
+  ],
+  "potsdamer platz": [
+    "potsdamer platz"
+  ],
+  "nevern square": [
+    "nevern square"
+  ],
+  "cemetery road": [
+    "cemetery road"
+  ],
+  "grolmanstraße": [
+    "grolmanstraße",
+    "grolman straße"
   ],
   "southwest 26th street": [
     "southwest 26th street"
@@ -16,10 +36,10 @@
     "northwest 26th street"
   ],
   "cr 34": [
-    "county route 34",
-    "crescent 34",
+    "creek 34",
     "county road 34",
-    "creek 34"
+    "county route 34",
+    "crescent 34"
   ],
   "west 26th street place": [
     "west 26th street place"
@@ -37,63 +57,66 @@
     "rigaer strasse"
   ],
   "markgrafenstraße": [
-    "markgrafenstrasse",
-    "markgrafen strasse"
+    "markgrafenstraße",
+    "markgrafen straße"
   ],
   "potsdamer straße": [
     "potsdamer strasse"
   ],
   "l 69": [
+    "left 69",
     "lane 69",
     "l 69",
     "50 69",
     "level 69",
+    "links 69",
     "lang 69",
     "lange 69"
-  ],
-  "potsdamer platz": [
-    "potsdamer platz"
   ],
   "alte potsdamer straße": [
     "alte potsdamer strasse"
   ],
   "b 1": [
-    "bei 1",
-    "b 1"
+    "b 1",
+    "bei 1"
   ],
   "s+u potsdamer platz": [
     "s+u potsdamer platz"
   ],
   "lützowstraße/potsdamer straße": [
-    "luetzowstrasse potsdamer strasse",
-    "luetzow strasse potsdamer strasse",
-    "lutzowstrasse potsdamer strasse",
-    "lutzow strasse potsdamer strasse"
+    "luetzowstraße potsdamer strasse",
+    "luetzow straße potsdamer strasse",
+    "lutzowstraße potsdamer strasse",
+    "lutzow straße potsdamer strasse"
   ],
   "s potsdamer platz/voßstraße": [
-    "see potsdamer platz vossstrasse",
-    "s potsdamer platz vossstrasse",
-    "sud potsdamer platz vossstrasse",
-    "see potsdamer platz voss strasse",
-    "s potsdamer platz voss strasse",
-    "sud potsdamer platz voss strasse"
+    "sud potsdamer platz vossstraße",
+    "s potsdamer platz vossstraße",
+    "see potsdamer platz vossstraße",
+    "sud potsdamer platz voss straße",
+    "s potsdamer platz voss straße",
+    "see potsdamer platz voss straße"
   ],
   "potsdamer platz arkaden": [
     "potsdamer platz arkaden"
   ],
   "l 204": [
+    "left 204",
     "lane 204",
     "l 204",
     "50 204",
     "level 204",
+    "links 204",
     "lang 204",
     "lange 204"
   ],
   "l 40": [
+    "left 40",
     "lane 40",
     "l 40",
     "50 40",
     "level 40",
+    "links 40",
     "lang 40",
     "lange 40"
   ],
@@ -101,98 +124,115 @@
     "kleine potsdamer strasse"
   ],
   "l 79": [
+    "left 79",
     "lane 79",
     "l 79",
     "50 79",
     "level 79",
+    "links 79",
     "lang 79",
     "lange 79"
   ],
   "goethestraße/potsdamer straße": [
-    "goethestrasse potsdamer strasse",
-    "goethe strasse potsdamer strasse"
+    "goethestraße potsdamer strasse",
+    "goethe straße potsdamer strasse"
   ],
   "b 273": [
-    "bei 273",
-    "b 273"
+    "b 273",
+    "bei 273"
   ],
   "k 6960": [
     "k 6960",
     "kalea 6960",
+    "kamp 6960",
     "katu 6960"
   ],
   "l 77": [
+    "left 77",
     "lane 77",
     "l 77",
     "50 77",
     "level 77",
+    "links 77",
     "lang 77",
     "lange 77"
   ],
   "l 78": [
+    "left 78",
     "lane 78",
     "l 78",
     "50 78",
     "level 78",
+    "links 78",
     "lang 78",
     "lange 78"
   ],
   "k 6909": [
     "k 6909",
     "kalea 6909",
+    "kamp 6909",
     "katu 6909"
   ],
   "l 90": [
+    "left 90",
     "lane 90",
     "l 90",
     "50 90",
     "level 90",
+    "links 90",
     "lang 90",
     "lange 90"
   ],
   "l 86": [
+    "left 86",
     "lane 86",
     "l 86",
     "50 86",
     "level 86",
+    "links 86",
     "lang 86",
     "lange 86"
   ],
   "l 92": [
+    "left 92",
     "lane 92",
     "l 92",
     "50 92",
     "level 92",
+    "links 92",
     "lang 92",
     "lange 92"
   ],
   "b 102": [
-    "bei 102",
-    "b 102"
+    "b 102",
+    "bei 102"
   ],
   "k 7220": [
     "k 7220",
     "kalea 7220",
+    "kamp 7220",
     "katu 7220"
   ],
   "k 7221": [
     "k 7221",
     "kalea 7221",
+    "kamp 7221",
     "katu 7221"
   ],
   "k 7": [
     "k 7",
     "kalea 7",
+    "kamp 7",
     "katu 7"
   ],
   "willow avenue": [
     "willow avenue"
   ],
   "cr 634": [
-    "county route 634",
-    "crescent 634",
+    "creek 634",
     "county road 634",
-    "creek 634"
+    "county route 634",
+    "crescent 634"
   ],
   "brookwillow avenue": [
     "brookwillow avenue"
@@ -471,10 +511,10 @@
     "end willow avenue"
   ],
   "laurel place & willow avenue": [
-    "laurel place  & willow avenue"
+    "laurel place & willow avenue"
   ],
   "maple & willow aves": [
-    "maple  & willow avenues"
+    "maple & willow avenues"
   ],
   "west willow avenue": [
     "west willow avenue"
@@ -490,7 +530,7 @@
     "willow avenue aka 265 7th"
   ],
   "willow avenue (a & b)": [
-    "willow avenue a b"
+    "willow avenue a & b"
   ],
   "willow avenue extension": [
     "willow avenue extension"
@@ -499,7 +539,7 @@
     "willow avenue lake "
   ],
   "willow avenue & railroad": [
-    "willow avenue railroad"
+    "willow avenue & railroad"
   ],
   "willow avenue rear": [
     "willow avenue rear"
@@ -510,17 +550,11 @@
   "willow avenue - rear": [
     "willow avenue rear"
   ],
-  "nevern square": [
-    "nevern square"
-  ],
   "nevern road": [
     "nevern road"
   ],
   "nevern place": [
     "nevern place"
-  ],
-  "cemetery road": [
-    "cemetery road"
   ],
   "lingshire rd": [
     "lingshire road"
@@ -547,8 +581,8 @@
     "birch creek road"
   ],
   "big sky ln": [
-    "big sky line",
-    "big sky lane"
+    "big sky lane",
+    "big sky line"
   ],
   "birky rd": [
     "birky road"
@@ -560,8 +594,8 @@
     "us highway 89"
   ],
   "us hwy 12 e": [
-    "us highway 12 e",
-    "us highway 12 east"
+    "us highway 12 east",
+    "us highway 12 e"
   ],
   "feddes rd": [
     "feddes road"
@@ -579,8 +613,8 @@
     "cottonwood creek road"
   ],
   "findon ln": [
-    "findon line",
-    "findon lane"
+    "findon lane",
+    "findon line"
   ],
   "main st": [
     "main street",
@@ -593,16 +627,16 @@
     "b st"
   ],
   "c st": [
-    "centre street",
-    "centre saint",
     "center street",
     "center saint",
+    "central street",
+    "central saint",
     "c street",
     "100 street",
     "c saint",
     "100 saint",
-    "central street",
-    "central saint"
+    "centre street",
+    "centre saint"
   ],
   "merino ave": [
     "merino avenue",
@@ -633,8 +667,7 @@
   ],
   "crazy m ranch rd": [
     "crazy m ranch road",
-    "crazy 1000 ranch road",
-    "crazy mail ranch road"
+    "crazy 1000 ranch road"
   ],
   "brekey rd": [
     "brekey road"
@@ -668,12 +701,12 @@
     "stud horse road"
   ],
   "bingham ln": [
-    "bingham line",
-    "bingham lane"
+    "bingham lane",
+    "bingham line"
   ],
   "jackson ln rd": [
-    "jackson line road",
-    "jackson lane road"
+    "jackson lane road",
+    "jackson line road"
   ],
   "monroe st": [
     "monroe street",
@@ -684,178 +717,198 @@
     "1st avenue nw"
   ],
   "n central ave": [
+    "north central avenida",
+    "north central avenue",
+    "n central avenida",
     "n central avenue",
-    "north central avenue"
+    "nosso central avenida",
+    "nosso central avenue",
+    "norte central avenida",
+    "norte central avenue"
   ],
   "1st ave ne": [
     "1st avenue ne",
-    "1st avenue northeast",
-    "1st avenue nebraska"
+    "1st avenue nebraska",
+    "1st avenue northeast"
   ],
   "e baker st": [
-    "e baker street",
-    "e baker saint",
     "east baker street",
-    "east baker saint"
+    "east baker saint",
+    "e baker street",
+    "e baker saint"
   ],
   "e grove st": [
-    "e grove street",
-    "e grove saint",
     "east grove street",
-    "east grove saint"
+    "east grove saint",
+    "e grove street",
+    "e grove saint"
   ],
   "e woodson st": [
-    "e woodson street",
-    "e woodson saint",
     "east woodson street",
-    "east woodson saint"
+    "east woodson saint",
+    "e woodson street",
+    "e woodson saint"
   ],
   "2nd ave ne": [
     "2nd avenue ne",
-    "2nd avenue northeast",
-    "2nd avenue nebraska"
+    "2nd avenue nebraska",
+    "2nd avenue northeast"
   ],
   "3rd ave ne": [
     "3rd avenue ne",
-    "3rd avenue northeast",
-    "3rd avenue nebraska"
+    "3rd avenue nebraska",
+    "3rd avenue northeast"
   ],
   "e laramie st": [
-    "e laramie street",
-    "e laramie saint",
     "east laramie street",
-    "east laramie saint"
+    "east laramie saint",
+    "e laramie street",
+    "e laramie saint"
   ],
   "e wright st": [
-    "e wright street",
-    "e wright saint",
     "east wright street",
-    "east wright saint"
+    "east wright saint",
+    "e wright street",
+    "e wright saint"
   ],
   "e washington st": [
-    "e washington street",
-    "e washington saint",
     "east washington street",
-    "east washington saint"
+    "east washington saint",
+    "e washington street",
+    "e washington saint"
   ],
   "4th ave ne": [
     "4th avenue ne",
-    "4th avenue northeast",
-    "4th avenue nebraska"
+    "4th avenue nebraska",
+    "4th avenue northeast"
   ],
   "5th ave ne": [
     "5th avenue ne",
-    "5th avenue northeast",
-    "5th avenue nebraska"
+    "5th avenue nebraska",
+    "5th avenue northeast"
   ],
   "e hampton st": [
-    "e hampton street",
-    "e hampton saint",
     "east hampton street",
-    "east hampton saint"
+    "east hampton saint",
+    "e hampton street",
+    "e hampton saint"
   ],
   "6th ave ne": [
     "6th avenue ne",
-    "6th avenue northeast",
-    "6th avenue nebraska"
+    "6th avenue nebraska",
+    "6th avenue northeast"
   ],
   "w main st": [
-    "w main street",
-    "w main saint",
     "west main street",
-    "west main saint"
+    "west main saint",
+    "w main street",
+    "w main saint"
   ],
   "e main st": [
-    "e main street",
-    "e main saint",
     "east main street",
-    "east main saint"
+    "east main saint",
+    "e main street",
+    "e main saint"
   ],
   "main st w": [
-    "main street w",
     "main street west",
-    "main saint w",
-    "main saint west"
+    "main street w",
+    "main saint west",
+    "main saint w"
   ],
   "2nd ave se": [
-    "2nd avenue southeast",
     "2nd avenue european company",
+    "2nd avenue southeast",
+    "2nd avenue suite",
     "2nd avenue se"
   ],
   "3rd ave se": [
-    "3rd avenue southeast",
     "3rd avenue european company",
+    "3rd avenue southeast",
+    "3rd avenue suite",
     "3rd avenue se"
   ],
   "e houston st": [
-    "e houston street",
-    "e houston saint",
     "east houston street",
-    "east houston saint"
+    "east houston saint",
+    "e houston street",
+    "e houston saint"
   ],
   "4th ave se": [
-    "4th avenue southeast",
     "4th avenue european company",
+    "4th avenue southeast",
+    "4th avenue suite",
     "4th avenue se"
   ],
   "e lincoln st": [
-    "e lincoln street",
-    "e lincoln saint",
     "east lincoln street",
-    "east lincoln saint"
+    "east lincoln saint",
+    "e lincoln street",
+    "e lincoln saint"
   ],
   "5th ave se": [
-    "5th avenue southeast",
     "5th avenue european company",
+    "5th avenue southeast",
+    "5th avenue suite",
     "5th avenue se"
   ],
   "1st ave se": [
-    "1st avenue southeast",
     "1st avenue european company",
+    "1st avenue southeast",
+    "1st avenue suite",
     "1st avenue se"
   ],
   "e chilton st": [
-    "e chilton street",
-    "e chilton saint",
     "east chilton street",
-    "east chilton saint"
+    "east chilton saint",
+    "e chilton street",
+    "e chilton saint"
   ],
   "e jefferson st": [
-    "e jefferson street",
-    "e jefferson saint",
     "east jefferson street",
-    "east jefferson saint"
+    "east jefferson saint",
+    "e jefferson street",
+    "e jefferson saint"
   ],
   "10th ave sw": [
     "10th avenue southwest",
     "10th avenue sw"
   ],
   "s central ave": [
+    "south central avenida",
     "south central avenue",
+    "san central avenida",
     "san central avenue",
-    "s central avenue"
+    "s central avenida",
+    "s central avenue",
+    "sul central avenida",
+    "sul central avenue",
+    "sao central avenida",
+    "sao central avenue",
+    "senhor central avenida",
+    "senhor central avenue"
   ],
   "e alabama st": [
-    "e alabama street",
-    "e alabama saint",
     "east alabama street",
-    "east alabama saint"
+    "east alabama saint",
+    "e alabama street",
+    "e alabama saint"
   ],
   "e brown st": [
-    "e brown street",
-    "e brown saint",
     "east brown street",
-    "east brown saint"
+    "east brown saint",
+    "e brown street",
+    "e brown saint"
   ],
   "5th ave sw": [
     "5th avenue southwest",
     "5th avenue sw"
   ],
   "e crawford st": [
-    "e crawford street",
-    "e crawford saint",
     "east crawford street",
-    "east crawford saint"
+    "east crawford saint",
+    "e crawford street",
+    "e crawford saint"
   ],
   "sw maginnis st": [
     "southwest maginnis street",
@@ -872,10 +925,10 @@
     "3rd avenue sw"
   ],
   "e maginnis st": [
-    "e maginnis street",
-    "e maginnis saint",
     "east maginnis street",
-    "east maginnis saint"
+    "east maginnis saint",
+    "e maginnis street",
+    "e maginnis saint"
   ],
   "folsom st": [
     "folsom street",
@@ -888,30 +941,32 @@
     "sw folsom saint"
   ],
   "se folsom st": [
-    "southeast folsom street",
-    "southeast folsom saint",
     "european company folsom street",
     "european company folsom saint",
+    "southeast folsom street",
+    "southeast folsom saint",
+    "suite folsom street",
+    "suite folsom saint",
     "se folsom street",
     "se folsom saint"
   ],
   "w folsom st": [
-    "w folsom street",
-    "w folsom saint",
     "west folsom street",
-    "west folsom saint"
+    "west folsom saint",
+    "w folsom street",
+    "w folsom saint"
   ],
   "e folsom st": [
-    "e folsom street",
-    "e folsom saint",
     "east folsom street",
-    "east folsom saint"
+    "east folsom saint",
+    "e folsom street",
+    "e folsom saint"
   ],
   "e hancock st": [
-    "e hancock street",
-    "e hancock saint",
     "east hancock street",
-    "east hancock saint"
+    "east hancock saint",
+    "e hancock street",
+    "e hancock saint"
   ],
   "sw garfield st": [
     "southwest garfield street",
@@ -920,22 +975,22 @@
     "sw garfield saint"
   ],
   "w garfield st": [
-    "w garfield street",
-    "w garfield saint",
     "west garfield street",
-    "west garfield saint"
+    "west garfield saint",
+    "w garfield street",
+    "w garfield saint"
   ],
   "e garfield st": [
-    "e garfield street",
-    "e garfield saint",
     "east garfield street",
-    "east garfield saint"
+    "east garfield saint",
+    "e garfield street",
+    "e garfield saint"
   ],
   "e south st": [
-    "e south street",
-    "e south saint",
     "east south street",
-    "east south saint"
+    "east south saint",
+    "e south street",
+    "e south saint"
   ],
   "6th ave sw": [
     "6th avenue southwest",
@@ -945,17 +1000,17 @@
     "slaughter house road"
   ],
   "ramspeck ln": [
-    "ramspeck line",
     "ramspeck lane",
+    "ramspeck line",
     "ramspeck laan"
   ],
   "jackson ln": [
-    "jackson line",
-    "jackson lane"
+    "jackson lane",
+    "jackson line"
   ],
   "slaughter house ln": [
-    "slaughter house line",
-    "slaughter house lane"
+    "slaughter house lane",
+    "slaughter house line"
   ],
   "luppold rd": [
     "luppold road"
@@ -979,10 +1034,10 @@
     "2nd avenue sw"
   ],
   "w hampton st": [
-    "w hampton street",
-    "w hampton saint",
     "west hampton street",
-    "west hampton saint"
+    "west hampton saint",
+    "w hampton street",
+    "w hampton saint"
   ],
   "swmaginnis st": [
     "swmaginnis street",
@@ -1035,10 +1090,10 @@
     "ranch creek road s"
   ],
   "w houston st": [
-    "w houston street",
-    "w houston saint",
     "west houston street",
-    "west houston saint"
+    "west houston saint",
+    "w houston street",
+    "w houston saint"
   ],
   "cedar rd": [
     "cedar road"
@@ -1051,8 +1106,8 @@
   ],
   "luppold ln": [
     "luppold laan",
-    "luppold line",
-    "luppold lane"
+    "luppold lane",
+    "luppold line"
   ],
   "earling ave": [
     "earling avenue"
@@ -1073,8 +1128,8 @@
     "voldseth road"
   ],
   "n badger": [
-    "n badger",
-    "north badger"
+    "north badger",
+    "n badger"
   ],
   "wall st": [
     "wall street",
@@ -1104,17 +1159,17 @@
     "8th avenue sw"
   ],
   "w alabama st": [
-    "w alabama street",
-    "w alabama saint",
     "west alabama street",
-    "west alabama saint"
+    "west alabama saint",
+    "w alabama street",
+    "w alabama saint"
   ],
   "forest rd south": [
     "forest road south"
   ],
   "us hwy 89 n": [
-    "us highway 89 n",
-    "us highway 89 north"
+    "us highway 89 north",
+    "us highway 89 n"
   ],
   "west roadway": [
     "west roadway"
@@ -1144,8 +1199,8 @@
     "sunrise doctor"
   ],
   "jackrabbit ln": [
-    "jackrabbit line",
-    "jackrabbit lane"
+    "jackrabbit lane",
+    "jackrabbit line"
   ],
   "sagebrush trl": [
     "sagebrush trail"
@@ -1164,56 +1219,56 @@
     "cemetery road"
   ],
   "w south st": [
-    "w south street",
-    "w south saint",
     "west south street",
-    "west south saint"
+    "west south saint",
+    "w south street",
+    "w south saint"
   ],
   "badger st": [
     "badger street",
     "badger saint"
   ],
   "e monroe st": [
-    "e monroe street",
-    "e monroe saint",
     "east monroe street",
-    "east monroe saint"
+    "east monroe saint",
+    "e monroe street",
+    "e monroe saint"
   ],
   "studhorse rd": [
     "studhorse road"
   ],
   "folsom st w": [
-    "folsom street w",
     "folsom street west",
-    "folsom saint w",
-    "folsom saint west"
+    "folsom street w",
+    "folsom saint west",
+    "folsom saint w"
   ],
   "w chilton st": [
-    "w chilton street",
-    "w chilton saint",
     "west chilton street",
-    "west chilton saint"
+    "west chilton saint",
+    "w chilton street",
+    "w chilton saint"
   ],
   "grove st": [
     "grove street",
     "grove saint"
   ],
   "lind ln": [
-    "lind line",
     "lind lane",
+    "lind line",
     "lind laan"
   ],
   "baker st w": [
-    "baker street w",
     "baker street west",
-    "baker saint w",
-    "baker saint west"
+    "baker street w",
+    "baker saint west",
+    "baker saint w"
   ],
   "south st e": [
-    "south street e",
     "south street east",
-    "south saint e",
-    "south saint east"
+    "south street e",
+    "south saint east",
+    "south saint e"
   ],
   "1st st s": [
     "1st street south",
@@ -1227,12 +1282,12 @@
     "lake road"
   ],
   "mountainview ln": [
-    "mountainview line",
-    "mountainview lane"
+    "mountainview lane",
+    "mountainview line"
   ],
   "bachler ln": [
-    "bachler line",
     "bachler lane",
+    "bachler line",
     "bachler laan"
   ],
   "ryan st": [
@@ -1249,7 +1304,7 @@
     "southeast road"
   ],
   "hitching post rd": [
-    "hitching post rd"
+    "hitching post road"
   ],
   "hidden trl": [
     "hidden trail"
@@ -1268,23 +1323,23 @@
     "south saint"
   ],
   "zehntner ln": [
-    "zehntner line",
-    "zehntner lane"
+    "zehntner lane",
+    "zehntner line"
   ],
   "painted pony ln": [
-    "painted pony line",
-    "painted pony lane"
+    "painted pony lane",
+    "painted pony line"
   ],
   "n star rd": [
-    "n star road",
-    "north star road"
+    "north star road",
+    "n star road"
   ],
   "grande rd": [
     "grande road"
   ],
   "goat mountain f": [
-    "goat mountain flat",
-    "goat mountain f"
+    "goat mountain f",
+    "goat mountain front"
   ],
   "panorama dr": [
     "panorama drive",
@@ -1305,9 +1360,9 @@
     "berg road"
   ],
   "castle mt rd": [
-    "castle montana road",
     "castle mt road",
-    "castle mount road"
+    "castle mount road",
+    "castle montana road"
   ],
   "castle mountain rd": [
     "castle mountain road"
@@ -1317,10 +1372,10 @@
     "brown saint"
   ],
   "crawford st w": [
-    "crawford street w",
     "crawford street west",
-    "crawford saint w",
-    "crawford saint west"
+    "crawford street w",
+    "crawford saint west",
+    "crawford saint w"
   ],
   "sw10th ave": [
     "sw10th avenue",
@@ -1328,7 +1383,7 @@
     "sw 10th avenue"
   ],
   "castle town rd": [
-    "castle town rd"
+    "castle town road"
   ],
   "nat for dev rd 581": [
     "nat for dev road 581"
@@ -1347,12 +1402,12 @@
     "crawford saint"
   ],
   "fox wood ln": [
-    "fox wood line",
-    "fox wood lane"
+    "fox wood lane",
+    "fox wood line"
   ],
   "foxwood ln": [
-    "foxwood line",
-    "foxwood lane"
+    "foxwood lane",
+    "foxwood line"
   ],
   "west 26th st": [
     "west 26th street",
@@ -1360,16 +1415,5 @@
   ],
   "": [
     ""
-  ],
-  "grolmanstrasse": [
-    "grolmanstrasse",
-    "grolman strasse"
-  ],
-  "rigaer strasse": [
-    "rigaer strasse"
-  ],
-  "markgrafenstrasse": [
-    "markgrafenstrasse",
-    "markgrafen strasse"
   ]
 }


### PR DESCRIPTION
This PR builds on https://github.com/pelias/interpolation/pull/60 to allow us to merge support for libpostal 1.0!

It updates all the mock libpostal responses for libpostal 1.0, makes it easier to configure the libpostal mocking code to update its stored responses, and adds instructions on how to do that in the readme.