### PR TITLE
Make scripts work with docker-compose

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "express": "^4.14.0",
     "fs-extra": "^3.0.1",
     "jsftp": "^2.0.0",
+    "lodash": "^4.17.4",
     "node-postal": "^1.0.0",
     "pbf2json": "^4.2.0",
     "pelias-config": "^2.11.0",
@@ -48,7 +49,6 @@
   },
   "devDependencies": {
     "jshint": "^2.9.3",
-    "lodash": "^4.17.4",
     "npm-check": "git://github.com/orangejulius/npm-check.git#disable-update-check",
     "precommit-hook": "^3.0.0",
     "proxyquire": "^1.7.11",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "cli-table2": "^0.2.0",
     "csv-parse": "^1.2.0",
     "express": "^4.14.0",
+    "fs-extra": "^3.0.1",
     "jsftp": "^2.0.0",
     "node-postal": "^1.0.0",
     "pbf2json": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "jsftp": "^2.0.0",
     "node-postal": "^1.0.0",
     "pbf2json": "^4.2.0",
+    "pelias-config": "^2.11.0",
     "pelias-logger": "^0.2.0",
     "quadtree": "^1.1.3",
     "require-dir": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "lint": "jshint .",
     "validate": "npm ls",
     "check-dependencies": "node_modules/.bin/npm-check --production --ignore node-postal --ignore pbf2json",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post",
+    "download-tiger": "node script/js/update_tiger.js",
+    "build": "./script/build.sh"
   },
   "repository": {
     "type": "git",
@@ -24,19 +26,23 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
+    "@mapbox/polyline": "^0.2.0",
+    "async": "^2.5.0",
     "cli-table2": "^0.2.0",
     "csv-parse": "^1.2.0",
     "express": "^4.14.0",
+    "jsftp": "^2.0.0",
     "node-postal": "^1.0.0",
     "pbf2json": "^4.2.0",
-    "@mapbox/polyline": "^0.2.0",
+    "pelias-logger": "^0.2.0",
     "quadtree": "^1.1.3",
     "require-dir": "^0.3.1",
     "serve-index": "^1.8.0",
     "split2": "^2.1.1",
     "sqlite3": "^3.1.7",
     "through2": "^2.0.3",
-    "through2-batch": "^1.0.1"
+    "through2-batch": "^1.0.1",
+    "unzip": "^0.1.11"
   },
   "devDependencies": {
     "jshint": "^2.9.3",

--- a/readme.md
+++ b/readme.md
@@ -311,6 +311,7 @@ the `PELIAS_CONFIG` environment variable should be set. You can read more detail
 Note that `datapath` will default to `./data/downloads` if not specified.
 
 To filter the TIGER data download you can set `state_code` property in the `pelias-config` file to the 2 digit code of the state to be downloaded.
+In the example configuration above, the state code for Oregon, `41`, is used to limit the download.
 The state code can found by referencing the table below. If no `state_code` value is found, all US data will be downloaded.
  
 | code | state |

--- a/readme.md
+++ b/readme.md
@@ -281,10 +281,37 @@ cat /data/new_zealand.polylines | docker run -i -v /data:/data pelias/interpolat
 
 ### running a build in the docker container
 
-the build scripts are configurable via environment variables, you will need to download your data before running the build command.
+The build scripts are configurable via a combination of environment variables and a `pelias-config` json file.
+You will need to download your data before running the build command.
 
-To filter the TIGER data download you can set STATE_CODE environment variable to the 2 digit code of the state to be downloaded.
-The state code can found by referencing the table below. If no STATE_CODE value is found, all US data will be downloaded.
+To make use of the `pelias-config` functionality, you'll need to create a new json file called `pelias.json` for example.
+The relevant parts of that new file should look as follows. To direct to download script to this file, 
+the `PELIAS_CONFIG` environment variable should be set. You can read more details on how to use the `pelias-config` module
+[here](https://github.com/pelias/config).
+
+```javascript
+{
+  "imports": {
+    "interpolation": {
+      "download": {
+        "tiger": {
+          "datapath": "/tmp/data/tiger/",
+          "states": [
+            {
+              "state_code": 41
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+Note that `datapath` will default to `./data/downloads` if not specified.
+
+To filter the TIGER data download you can set `state_code` property in the `pelias-config` file to the 2 digit code of the state to be downloaded.
+The state code can found by referencing the table below. If no `state_code` value is found, all US data will be downloaded.
  
 | code | state |
 | --- | --- |
@@ -355,9 +382,8 @@ unzip /tmp/data/berlin.zip -d /tmp/data
 # download openstreetmap data
 curl -s https://s3.amazonaws.com/metro-extracts.mapzen.com/berlin_germany.osm.pbf > /tmp/data/berlin.osm.pbf
 
-#download tiger data
-export TIGERPATH=/tmp/data/tiger #make sure that directory exists
-export STATE_CODE=41
+# download tiger data (note data directory will be created if it doesn't exist)
+export PELIAS_CONFIG=./pelias.json
 npm run download-tiger
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -283,6 +283,64 @@ cat /data/new_zealand.polylines | docker run -i -v /data:/data pelias/interpolat
 
 the build scripts are configurable via environment variables, you will need to download your data before running the build command.
 
+To filter the TIGER data download you can set STATE_CODE environment variable to the 2 digit code of the state to be downloaded.
+The state code can found by referencing the table below. If no STATE_CODE value is found, all US data will be downloaded.
+ 
+| code | state |
+| --- | --- |
+| 01 | Alabama              |
+| 02 | Alaska               |
+| 04 | Arizona              |
+| 05 | Arkansas             |
+| 06 | California           |
+| 08 | Colorado             |
+| 09 | Connecticut          |
+| 10 | Delaware             |
+| 11 | District of Columbia |
+| 12 | Florida              |
+| 13 | Georgia              |
+| 15 | Hawaii               |
+| 16 | Idaho                |
+| 17 | Illinois             |
+| 18 | Indiana              |
+| 19 | Iowa                 |
+| 20 | Kansas               |
+| 21 | Kentucky             |
+| 22 | Louisiana            |
+| 23 | Maine                |
+| 24 | Maryland             |
+| 25 | Massachusetts        |
+| 26 | Michigan             |
+| 27 | Minnesota            |
+| 28 | Mississippi          |
+| 29 | Missouri             |
+| 30 | Montana              |
+| 31 | Nebraska             |
+| 32 | Nevada               |
+| 33 | New Hampshire        |
+| 34 | New Jersey           |
+| 35 | New Mexico           |
+| 36 | New York             |
+| 37 | North Carolina       |
+| 38 | North Dakota         |
+| 39 | Ohio                 |
+| 40 | Oklahoma             |
+| 41 | Oregon               |
+| 42 | Pennsylvania         |
+| 72 | Puerto Rico          |
+| 44 | Rhode Island         |
+| 45 | South Carolina       |
+| 46 | South Dakota         |
+| 47 | Tennessee            |
+| 48 | Texas                |
+| 49 | Utah                 |
+| 50 | Vermont              |
+| 51 | Virginia             |
+| 53 | Washington           |
+| 54 | West Virginia        |
+| 55 | Wisconsin            |
+| 56 | Wyoming              |
+
 ```bash
 # prepare a build directory and a data directory to hold the newly created database files
 mkdir -p /tmp/data/berlin
@@ -296,6 +354,11 @@ unzip /tmp/data/berlin.zip -d /tmp/data
 
 # download openstreetmap data
 curl -s https://s3.amazonaws.com/metro-extracts.mapzen.com/berlin_germany.osm.pbf > /tmp/data/berlin.osm.pbf
+
+#download tiger data
+export TIGERPATH=/tmp/data/tiger #make sure that directory exists
+export STATE_CODE=41
+npm run download-tiger
 ```
 
 we will mount `/tmp/data` on the local machine as `/data` inside the container, so be careful to set paths as they appear inside the container.

--- a/script/build.sh
+++ b/script/build.sh
@@ -15,10 +15,13 @@ export TIMESTAMP=$(date +"%m-%d-%Y-%H:%M:%S");
 export PBF2JSON_BIN="$DIR/../node_modules/pbf2json/build/pbf2json.linux-x64";
 
 # location of data files
-export WORKINGDIR="${WORKINGDIR:-"/mnt/pelias"}"
-export POLYLINE_FILE="$WORKINGDIR/data/polylines/planet.polylines"; # the file containing all the streets
-export OAPATH="$WORKINGDIR/data/oa"; # base path of openaddresses file system
-export PBF2JSON_FILE="$WORKINGDIR/data/osm/planet-latest.osm.pbf";
+export WORKINGDIR="${WORKINGDIR:-"/mnt/pelias"}";
+# the file containing all the streets
+export POLYLINE_FILE="${POLYLINE_FILE:-"$WORKINGDIR/data/polylines/planet.polylines"}";
+# base path of openaddresses file system
+export OAPATH="${OAPATH:-"$WORKINGDIR/data/oa"}";
+ # base path of osm pbf file
+export PBF2JSON_FILE="${PBF2JSON_FILE:-"$WORKINGDIR/data/osm/planet-latest.osm.pbf"}";
 
 # a directory where all builds will live
 BUILDS="$WORKINGDIR/interpolation/builds";
@@ -27,35 +30,46 @@ BUILDS="$WORKINGDIR/interpolation/builds";
 [ -d $BUILDS ] || mkdir -p $BUILDS;
 
 # a directory where this specific build will live
-export BUILDDIR="$BUILDS/$TIMESTAMP";
+export BUILDDIR="${BUILDDIR:-"$BUILDS/$TIMESTAMP"}";
 [ -d $BUILDDIR ] || mkdir -p $BUILDDIR;
 
 # location of temp files
 export SQLITE_TMPDIR="$BUILDDIR/tmp"; # a directory with enough free space to store sqlite tmp files
 export PBF2JSON_TMPDIR="$BUILDDIR/tmp/leveldb"; # a directory with enough free space to store leveldb tmp files
 
+echo "$BUILDDIR"
+echo "$WORKINGDIR"
+
 # run polyline importer
+echo "- importing polylines"
 $DIR/import.sh;
 
 # archive street database (using parallel gzip when available)
+echo "- archiving street database
 if type pigz >/dev/null
   then pigz -k -c --best "$BUILDDIR/street.db" > "$BUILDDIR/street.db.gz";
   else gzip -c --best "$BUILDDIR/street.db" > "$BUILDDIR/street.db.gz";
 fi
 
 # run openaddresses conflation
+echo "- conflating openaddresses"
 $DIR/conflate_oa.sh;
 
 # run openstreetmap conflation
+echo "- conflating openstreetmap"
 $DIR/conflate_osm.sh;
 
 # run tiger conflation
+echo "- conflating tiger"
 $DIR/conflate_tiger.sh;
 
 # run vertex interpolation
+echo "- interpolating vertices"
 $DIR/vertices.sh;
 
 # archive address database (using parallel gzip when available)
+echo "- archiving address database"
+
 if type pigz >/dev/null
   then pigz -k -c --best "$BUILDDIR/address.db" > "$BUILDDIR/address.db.gz";
   else gzip -c --best "$BUILDDIR/address.db" > "$BUILDDIR/address.db.gz";
@@ -66,6 +80,8 @@ rm -rf "$SQLITE_TMPDIR" "$PBF2JSON_TMPDIR"; # remove tmp files
 
 # record build meta data
 METAFILE="$BUILDDIR/build.meta";
+
+echo "- generating meta file"
 
 echo "-- file system --" > "$METAFILE";
 ls -lah "$BUILDDIR" >> "$METAFILE";
@@ -83,3 +99,7 @@ sqlite3 -echo "$BUILDDIR/address.db" "SELECT COUNT(*) FROM address;" >> "$METAFI
 
 # update 'current' symlink
 ln -sfn "$BUILDDIR" "$BUILDS/current";
+
+echo
+echo "Build completed!"
+echo

--- a/script/build.sh
+++ b/script/build.sh
@@ -37,9 +37,6 @@ export BUILDDIR="${BUILDDIR:-"$BUILDS/$TIMESTAMP"}";
 export SQLITE_TMPDIR="$BUILDDIR/tmp"; # a directory with enough free space to store sqlite tmp files
 export PBF2JSON_TMPDIR="$BUILDDIR/tmp/leveldb"; # a directory with enough free space to store leveldb tmp files
 
-echo "$BUILDDIR"
-echo "$WORKINGDIR"
-
 # run polyline importer
 echo "- importing polylines"
 $DIR/import.sh;

--- a/script/build.sh
+++ b/script/build.sh
@@ -45,7 +45,7 @@ echo "- importing polylines"
 $DIR/import.sh;
 
 # archive street database (using parallel gzip when available)
-echo "- archiving street database
+echo "- archiving street database"
 if type pigz >/dev/null
   then pigz -k -c --best "$BUILDDIR/street.db" > "$BUILDDIR/street.db.gz";
   else gzip -c --best "$BUILDDIR/street.db" > "$BUILDDIR/street.db.gz";

--- a/script/conflate_osm.sh
+++ b/script/conflate_osm.sh
@@ -10,7 +10,7 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd );
 # ---- pbf2json ----
 
 # location of pbf2json binary
-PBF2JSON_BIN=${PBF2JSON_BIN:-"pbf2json.linux-x64"};
+PBF2JSON_BIN=${PBF2JSON_BIN:-"$DIR/../node_modules/pbf2json/build/pbf2json.linux-x64"};
 
 # ensure pbf2json exists and is executable
 if [[ ! -f $PBF2JSON_BIN || ! -x $PBF2JSON_BIN ]]; then

--- a/script/conflate_tiger.sh
+++ b/script/conflate_tiger.sh
@@ -56,8 +56,9 @@ if [ ! -d "$TIGERPATH/shapefiles" ]; then
   exit 1;
 fi
 
-# recurse through filesystem listing all .shp file names
-find "$TIGERPATH/shapefiles" -type f -iname "*.shp" -print0 |\
+# recurse through filesystem listing all .shx file names
+# some county zip packages are missing .shx which causes the ogr2ogr script to fail
+find "$TIGERPATH/shapefiles" -type f -iname "*.shx" -print0 |\
   while IFS= read -r -d $'\0' filename; do
 
     # echo filename to stderr

--- a/script/import.sh
+++ b/script/import.sh
@@ -38,4 +38,4 @@ export SQLITE_TMPDIR=${SQLITE_TMPDIR:-"$BUILDDIR/tmp"};
 rm -f $PROC_STDOUT $PROC_STDERR;
 
 # run import
-cat $POLYLINE_FILE | time -p node $DIR/../cmd/polyline.js $STREET_DB 1>$PROC_STDOUT 2>$PROC_STDERR;
+cat $POLYLINE_FILE | node $DIR/../cmd/polyline.js $STREET_DB 1>$PROC_STDOUT 2>$PROC_STDERR;

--- a/script/js/update_tiger.js
+++ b/script/js/update_tiger.js
@@ -17,8 +17,6 @@ if (_.isEmpty(STATES)) {
   STATES = [ {state_code: '' } ];
 }
 
-console.log(STATES);
-
 // iterate over all the desired states, or get all if no states specified
 async.eachSeries(STATES, download, (err)=>{
   if (err) {

--- a/script/js/update_tiger.js
+++ b/script/js/update_tiger.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const JSFtp = require('jsftp');
+const async = require('async');
+const path = require('path');
+const fs = require('fs');
+const unzip = require('unzip');
+const logger = require('pelias-logger').get('update_tiger');
+
+
+download((err)=>{
+  if (err) {
+    logger.error(err);
+    process.exit(1);
+  }
+
+  process.exit(0);
+});
+
+function download(callback) {
+  const context = {
+    ftp: new JSFtp({
+      host: 'ftp2.census.gov'
+    }),
+    stateCode: process.env.STATE_CODE || '',
+    targetDir: process.env.TIGERPATH || './data/downloads/',
+    files: []
+  };
+
+  async.series(
+    [
+      // get a list of relevant filenames
+      getFilteredFileList.bind(null, context),
+      // download all identified files, upzip, remove zip
+      downloadFilteredFiles.bind(null, context)
+    ],
+    (err) => {
+      if (err) {
+        logger.error(err);
+      }
+      callback(err);
+    });
+}
+
+function getFilteredFileList(context, callback) {
+  // note that if context.stateCode is an empty string, all files will be listed
+  context.ftp.list(`/geo/tiger/TIGER2016/ADDRFEAT/tl_2016_${context.stateCode}*.zip`, (err, res) => {
+    if (err) {
+      return callback(err);
+    }
+
+    // output of the list command looks like a typical ls command in unix
+    // this line will split the output into lines, and from each line grab the end of the file
+    // (all filenames are fixed length 27 chars)
+    // then it will trim the names and filter out any empty ones
+    context.files = res.split('\n').map((file)=>(file.substr(-27).trim())).filter((file)=>(file.length > 0));
+
+    callback();
+  });
+}
+
+function downloadFilteredFiles(context, callback) {
+  // must use eachSeries here because the ftp connection only allows one download at a time
+  async.eachSeries(context.files, downloadFile.bind(null, context), callback);
+}
+
+function downloadFile(context, filename, callback) {
+  const localFile = path.join(context.targetDir, filename);
+
+  context.ftp.get(`/geo/tiger/TIGER2016/ADDRFEAT/${filename}`, localFile, (err)=> {
+    if (err) {
+      return callback(err);
+    }
+
+    logger.info(`Downloaded ${filename}`);
+
+    // unzip downloaded file
+    fs.createReadStream(localFile).pipe(unzip.Extract({ path: context.targetDir })).on('finish', (err) => {
+      if (err) {
+        logger.error(`Failed to unzip ${filename}`);
+        return callback(err);
+      }
+
+      // delete zip file after unzip is done
+      fs.unlinkSync(localFile);
+      callback();
+    });
+  });
+}


### PR DESCRIPTION
- Adds a new node.js script for downloading TIGER data with the ability to filter by state code
- Adds the ability to read the TIGER download configuration from pelias-config
- Updates the existing build scripts to work with docker-compose
- Adds helpful logging throughout the build process

Connected to pelias/pelias#506
