### PR TITLE
server: multicore

### DIFF
--- a/cmd/server.js
+++ b/cmd/server.js
@@ -1,5 +1,27 @@
 
-var express = require('express'),
+/**
+  The http server improves performance on multicore machines by using the
+  node core 'cluster' module to fork worker processes.
+
+  The default setting is to use all available CPUs, this will spawn 32 child
+  processes on a 32 core machine.
+
+  WARNING: each process loads a it's own copy of 'node-postal', so each process
+  will consume ~2GB of RAM.
+
+  If you would like to disable this feature (maybe because you are running
+  inside a container) then you can do so by setting the env var CPUS=1
+
+  You may also specify exactly how many child processes you would like to
+  spawn by setting the env var to a numeric value >1, eg CPUS=4
+
+  If the CPUS env var is set less than 1 or greater than os.cpus().length
+  then the default setting will be used (using all available cores).
+**/
+
+var os = require('os'),
+    express = require('express'),
+    cluster = require('cluster'),
     directory = require('serve-index'),
     polyline = require('@mapbox/polyline'),
     search = require('../api/search'),
@@ -16,9 +38,6 @@ const logger = require('pelias-logger').get('interpolation');
 const through = require( 'through2' );
 const _ = require('lodash');
 
-// optionally override port using env var
-var PORT = process.env.PORT || 3000;
-
 // help text
 if( process.argv.length !== 4 ){
   console.error('invalid args.');
@@ -27,6 +46,13 @@ if( process.argv.length !== 4 ){
   process.exit(1);
 }
 
+// select the amount of cpus we will use
+const envCpus = parseInt( process.env.CPUS, 10 );
+const cpus = Math.min( Math.max( envCpus || Infinity, 1 ), os.cpus().length );
+
+// optionally override port/host using env var
+var PORT = process.env.PORT || 3000;
+var HOST = process.env.HOST || undefined;
 var app = express();
 app.use(log());
 
@@ -208,10 +234,46 @@ app.use('/demo', express.static('demo'));
 // app.use('/builds', express.static('/data/builds'));
 // app.use('/builds', directory('/data/builds', { hidden: false, icons: false, view: 'details' }));
 
-app.listen( PORT, function() {
+// start multi-threaded server
+if( cpus > 1 ){
+  if( cluster.isMaster ){
+    console.error('[master] using %d cpus', cpus);
 
-  // force loading of libpostal
-  analyze.street( 'test street' );
+    // worker exit event
+    cluster.on('exit', (worker, code, signal) => {
+      console.error('[master] worker died', worker.process.pid);
+    });
 
-  console.log( 'server listening on port', PORT );
-});
+    // worker fork event
+    cluster.on('fork', (worker, code, signal) => {
+      console.error('[master] worker forked', worker.process.pid);
+    });
+
+    // fork workers
+    for( var c=0; c<cpus; c++ ){
+      cluster.fork();
+    }
+
+  } else {
+    app.listen( PORT, HOST, () => {
+
+      // force loading of libpostal
+      analyze.street( 'test street' );
+
+      console.error('[worker %d] listening on %s:%s', process.pid, HOST||'0.0.0.0', PORT);
+    });
+  }
+}
+
+// start single-threaded server
+else {
+  console.error('[master] using %d cpus', cpus);
+
+  app.listen( PORT, HOST, () => {
+
+    // force loading of libpostal
+    analyze.street( 'test street' );
+
+    console.log('[master] listening on %s:%s', HOST||'0.0.0.0', PORT);
+  });
+}


### PR DESCRIPTION
DO NOT MERGE

This PR enables multicore support for the interpolation service.

I do not think this should be merged in its current state due to:
> each process loads its own copy of 'node-postal', so each process will consume ~2GB of RAM.

We could consider defaulting to `1` process instead of `os.cpus().length` and then allow ops engineers to modify the setup to suit their environment using the `CPUS` env var.

Thoughts?