### PR TITLE
move docker_build script to file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,6 @@ ENV WORKINGDIR '/'
 # change working dir
 ENV WORKDIR /code/pelias/interpolation
 WORKDIR ${WORKDIR}
-
 ADD . ${WORKDIR}
 
 # Install app dependencies
@@ -37,8 +36,5 @@ RUN npm install
 # run tests
 RUN npm test
 
-# create script for building
-RUN echo 'export PBF2JSON_FILE=$(ls ${OSMPATH}/*.osm.pbf | head -n 1); export POLYLINE_FILE=$(ls ${POLYLINEPATH}/*.0sv | head -n 1); npm run build' > ./docker_build.sh;
-
-
+# entrypoint
 CMD [ "./interpolate", "server", "/data/interpolation/address.db", "/data/interpolation/street.db" ]

--- a/api/tiger.js
+++ b/api/tiger.js
@@ -16,8 +16,8 @@ function tiger(dataStream, addressDbPath, streetDbPath, done){
   query.attach(db, process.argv[3], 'street'); // attach street database
 
   dataStream
-    .pipe( stream.tiger.parse() ) // convert openstreetmap data to generic model
-    .pipe( stream.tiger.convert() ) // convert openstreetmap data to generic model
+    .pipe( stream.tiger.parse() ) // convert tiger data to generic model
+    .pipe( stream.tiger.convert() ) // convert tiger data to generic model
     .pipe( stream.address.batch() ) // batch records on the same street
     .pipe( stream.address.lookup( db ) ) // look up from db
     .pipe( stream.address.augment() ) // perform interpolation

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# update ENV vars to point to the first available file on disk
+export PBF2JSON_FILE=$(ls ${OSMPATH}/*.osm.pbf | head -n 1)
+export POLYLINE_FILE=$(ls ${POLYLINEPATH}/*.0sv | head -n 1)
+
+# run the build
+npm run build

--- a/stream/address/lookup.js
+++ b/stream/address/lookup.js
@@ -8,8 +8,11 @@ var fs = require('fs'),
 // open file descriptor 3 for logging conflation errors (when available)
 // note: to enable logging you need to attach the fd with a command such as:
 // $ node oa.js 3> conflate.skip
-process.conferr = fs.createWriteStream( null, { fd: 3 } );
-process.conferr.on( 'error', function(){ process.conferr = { write: function noop(){} }; });
+const hasFD3 = fs.statSync('/dev/fd/3').isFile();
+if( hasFD3 ){
+  process.conferr = fs.createWriteStream( null, { fd: 3 } );
+  process.conferr.on( 'error', function(){ process.conferr = { write: function noop(){} }; });
+}
 
 function streamFactory(db){
 
@@ -51,7 +54,7 @@ function streamFactory(db){
       if( !rows || !rows.length ){
 
         // log addresss which do not conflate to file descriptor 3 (when available)
-        if( process.conferr.writable ){
+        if( hasFD3 ){
           batch.forEach( function( address ){
             process.conferr.write( JSON.stringify( address ) + '\n' );
           });


### PR DESCRIPTION
note: rebased off https://github.com/pelias/interpolation/pull/111 please merge that PR first

external scripts reference a file called `docker_build.sh` which was being generated using an `echo` command as part of `Dockerfile`.

this PR moves that functionality to a physical file on disk so that it's easier to debug and reason about the whereabouts of that file when browsing the repo.

IMHO this workflow is a little messy and I would like to remove the `npm run build` step from here too, although I didn't yet as I'm not sure about which external scripts are depending on that behavior.