### PR TITLE
more robust checks to determine if fd3 is attached or not

### DIFF
--- a/api/tiger.js
+++ b/api/tiger.js
@@ -16,8 +16,8 @@ function tiger(dataStream, addressDbPath, streetDbPath, done){
   query.attach(db, process.argv[3], 'street'); // attach street database
 
   dataStream
-    .pipe( stream.tiger.parse() ) // convert openstreetmap data to generic model
-    .pipe( stream.tiger.convert() ) // convert openstreetmap data to generic model
+    .pipe( stream.tiger.parse() ) // convert tiger data to generic model
+    .pipe( stream.tiger.convert() ) // convert tiger data to generic model
     .pipe( stream.address.batch() ) // batch records on the same street
     .pipe( stream.address.lookup( db ) ) // look up from db
     .pipe( stream.address.augment() ) // perform interpolation

--- a/stream/address/lookup.js
+++ b/stream/address/lookup.js
@@ -8,8 +8,11 @@ var fs = require('fs'),
 // open file descriptor 3 for logging conflation errors (when available)
 // note: to enable logging you need to attach the fd with a command such as:
 // $ node oa.js 3> conflate.skip
-process.conferr = fs.createWriteStream( null, { fd: 3 } );
-process.conferr.on( 'error', function(){ process.conferr = { write: function noop(){} }; });
+const hasFD3 = fs.statSync('/dev/fd/3').isFile();
+if( hasFD3 ){
+  process.conferr = fs.createWriteStream( null, { fd: 3 } );
+  process.conferr.on( 'error', function(){ process.conferr = { write: function noop(){} }; });
+}
 
 function streamFactory(db){
 
@@ -51,7 +54,7 @@ function streamFactory(db){
       if( !rows || !rows.length ){
 
         // log addresss which do not conflate to file descriptor 3 (when available)
-        if( process.conferr.writable ){
+        if( hasFD3 ){
           batch.forEach( function( address ){
             process.conferr.write( JSON.stringify( address ) + '\n' );
           });


### PR DESCRIPTION
in nodejs version `4` it was possible to check `stream.writable === true` on a stream opened to a file descriptor, and if that fd was not attached then `.writable` would be `false`.

as of nodejs `6` this seems to no longer be true and so when the stream is first written, node crashes fatally with a core-dumped error.

this must be a recent change to node as our prior Travis tests were passing on 4 and 6.

this PR implements a more robust way of checking the fd is attached before writing to it.

I also fixed some line comments which were incorrect.