### PR TITLE
fix Dockerfile entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,5 @@ RUN npm install
 RUN npm test
 
 # entrypoint
-CMD [ "./interpolate", "server", "/data/interpolation/address.db", "/data/interpolation/street.db" ]
+ENTRYPOINT [ "./interpolate" ]
+CMD [ "server", "/data/interpolation/address.db", "/data/interpolation/street.db" ]


### PR DESCRIPTION
The `ENTRYPOINT` command seems to have been erroneously removed in https://github.com/pelias/interpolation/commit/1ede4e276e9a8b60273385837f099b11a8672377#diff-3254677a7917c6c01f55212f86c57fbf

The problem is that all the documentation expects: `ENTRYPOINT [ "./interpolate" ]`

resolves: https://github.com/pelias/interpolation/issues/117