### PR TITLE
remove docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,5 +37,4 @@ RUN npm install
 RUN npm test
 
 # entrypoint
-ENTRYPOINT [ "./interpolate" ]
-CMD [ "server", "/data/interpolation/address.db", "/data/interpolation/street.db" ]
+CMD [ "./interpolate", "server", "/data/interpolation/address.db", "/data/interpolation/street.db" ]

--- a/readme.md
+++ b/readme.md
@@ -278,7 +278,7 @@ you should now be able to access the web server locally at `http://localhost:500
 you can run any command supported by `./interpolate` via the docker container, such as:
 
 ```bash
-cat /data/new_zealand.polylines | docker run -i -v /data:/data pelias/interpolation polyline /data/nz.db
+cat /data/new_zealand.polylines | docker run --rm -it -v /data:/data pelias/interpolation ./interpolate polyline /data/nz.db
 ```
 
 ### running a build in the docker container
@@ -287,7 +287,7 @@ The build scripts are configurable via a combination of environment variables an
 You will need to download your data before running the build command.
 
 To make use of the `pelias-config` functionality, you'll need to create a new json file called `pelias.json` for example.
-The relevant parts of that new file should look as follows. To direct to download script to this file, 
+The relevant parts of that new file should look as follows. To direct to download script to this file,
 the `PELIAS_CONFIG` environment variable should be set. You can read more details on how to use the `pelias-config` module
 [here](https://github.com/pelias/config).
 
@@ -315,7 +315,7 @@ Note that `datapath` will default to `./data/downloads` if not specified.
 To filter the TIGER data download you can set `state_code` property in the `pelias-config` file to the 2 digit code of the state to be downloaded.
 In the example configuration above, the state code for Oregon, `41`, is used to limit the download.
 The state code can found by referencing the table below. If no `state_code` value is found, all US data will be downloaded.
- 
+
 | code | state |
 | --- | --- |
 | 01 | Alabama              |
@@ -399,7 +399,7 @@ docker run -i \ # run interactively (optionally daemonize with -d)
   -e 'POLYLINE_FILE=/data/berlin.0sv' \ # location of the polyline data
   -e 'OAPATH=/data/de' \ # location of the openaddresses data
   -e 'PBF2JSON_FILE=/data/berlin.osm.pbf' \ # location of the openstreetmap data
-  pelias/interpolation build
+  pelias/interpolation ./interpolate build
 ```
 
 once completed you should find the newly created `street.db` and `address.db` files in `/tmp/data/berlin` on your local machine.


### PR DESCRIPTION
The Dockerfile for this repo was originally written with the intention of having `--entrypoint=./interpolate`.

At [one point](https://github.com/pelias/interpolation/commit/1ede4e276e9a8b60273385837f099b11a8672377#diff-3254677a7917c6c01f55212f86c57fbf) this was changed to remove the `ENTRYPOINT` command.

So I [opened a PR](https://github.com/pelias/interpolation/pull/120) to put it back again :)

The problem is that we have documentation for both versions of ENTRYPOINT vs. no ENTRYPOINT, meaning that people are relying on it being one way or the other.

@orangejulius and I discussed it and came to the conclusion that, from now onward, we would not publish docker images with an `ENTRYPOINT`, this keeps the images consistent and predictable.

This PR removes the ENTRYPOINT and updates the readme to reflect the changes.

I have scanned the other repos and it seems like they are all in order, please let me know if I missed one.

resolves: https://github.com/pelias/interpolation/issues/123