### PR TITLE
improved error handling for polylines missing a valid name

### DIFF
--- a/stream/street/augment.js
+++ b/stream/street/augment.js
@@ -22,6 +22,14 @@ function streamFactory(){
     street.getNames().forEach( function( name ){
       names = names.concat( analyze.street( name ) );
     });
+
+    // if the source file contains no valid names for this polyline
+    if( !names.length ){
+      console.error( 'street has no valid names, check your 0sv file:' );
+      console.error( street.getEncodedPolyline() );
+      return next();
+    }
+
     street.setNames( names );
 
     // expand bbox


### PR DESCRIPTION
in the case where the `.0sv` extract contains a line which doesn't have a valid name, we currently throw a fatal error.

this PR changes that behavior to a warning so that one or two bad eggs don't spoil the whole bunch.

resolves: https://github.com/pelias/interpolation/issues/127