### PR TITLE
Fix support for OSX

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -444,6 +444,12 @@ To use Interpolation service with the Pelias API, [configure the pelias config f
 
 The `Dockerfile` in this repo has complete instructions on how to install everything from scratch on Ubuntu.
 
+### TIGER dependency on GDAL
+
+The TIGER importer requires the `ogr2ogr` binary from `gdal` version 2+ in order to extract data from the `.shp` files provided by the US Census Bureau.
+
+On linux this you can install this with a command such as `sudo apt-get install gdal-bin`, on OSX you will need to follow [this guide](https://www.karambelkar.info/2016/10/gdal-2-on-mac-with-homebrew/).
+
 ```bash
 npm install
 ```

--- a/stream/address/lookup.js
+++ b/stream/address/lookup.js
@@ -8,7 +8,8 @@ var fs = require('fs'),
 // open file descriptor 3 for logging conflation errors (when available)
 // note: to enable logging you need to attach the fd with a command such as:
 // $ node oa.js 3> conflate.skip
-const hasFD3 = fs.statSync('/dev/fd/3').isFile();
+var hasFD3 = false;
+try { hasFD3 = fs.statSync('/dev/fd/3').isFile(); } catch(e){}
 if( hasFD3 ){
   process.conferr = fs.createWriteStream( null, { fd: 3 } );
   process.conferr.on( 'error', function(){ process.conferr = { write: function noop(){} }; });

--- a/test/functional/action.js
+++ b/test/functional/action.js
@@ -96,7 +96,7 @@ module.exports.tiger = function(test, paths) {
 
     // conflate openstreetmap addresses
     var cmd = [
-      'ogr2ogr -f GeoJSON -t_srs crs:84 /vsistdout/', paths.fixture.tiger, '|',
+      'ogr2ogr -f GeoJSON -lco \'COORDINATE_PRECISION=7\' -t_srs crs:84 /vsistdout/', paths.fixture.tiger, '|',
       'node', exec.tiger, paths.db.address, paths.db.street,
       '1>', path.resolve( paths.reports, 'tiger.out' ),
       '2>', path.resolve( paths.reports, 'tiger.err' )


### PR DESCRIPTION
this PR fixes support for OSX (bad file descriptor errors) and also documents that GDAL is required for TIGER and how to go about installing it.

related: https://github.com/pelias/interpolation/pull/111