### PR TITLE
Use separate script files to avoid NPM calls and test failures

### DIFF
--- a/bin/download-tiger
+++ b/bin/download-tiger
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec node script/js/update_tiger.js

--- a/bin/funcs
+++ b/bin/funcs
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# run tests with pipefail to avoid false passes
+# see https://github.com/pelias/pelias/issues/744
+set -euo pipefail
+
+MOCK_LIBPOSTAL=true node test/_func.js | npx tap-spec

--- a/bin/units
+++ b/bin/units
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# run tests with pipefail to avoid false passes
+# see https://github.com/pelias/pelias/issues/744
+set -euo pipefail
+
+MOCK_LIBPOSTAL=true node test/_unit.js | npx tap-spec

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -5,4 +5,4 @@ export PBF2JSON_FILE=$(ls ${OSMPATH}/*.osm.pbf | head -n 1)
 export POLYLINE_FILE=$(ls ${POLYLINEPATH}/*.0sv | head -n 1)
 
 # run the build
-npm run build
+./script/build.sh

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "travis": "npm test && npm run funcs",
     "lint": "jshint .",
     "validate": "npm ls",
-    "download-tiger": "node script/js/update_tiger.js",
+    "download-tiger": "./bin/download-tiger",
     "build": "./script/build.sh"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "main": "index.js",
   "scripts": {
     "test": "npm run units",
-    "funcs": "MOCK_LIBPOSTAL=true node test/_func.js | tap-spec",
-    "units": "MOCK_LIBPOSTAL=true node test/_unit.js | tap-spec",
+    "funcs": "./bin/funcs",
+    "units": "./bin/units",
     "travis": "npm test && npm run funcs",
     "lint": "jshint .",
     "validate": "npm ls",


### PR DESCRIPTION
It's desirable to avoid calling `npm` when running Docker containers, since `npm` does not handle signals well, and also requires write access to the container's root filesystem.

Additionally, using a pipe in npm scripts was opening us up to the possibility of tests showing as passed when there actually was a fatal error.

This PR makes it possible to avoid calling `npm` in Docker containers, and uses dedicated test scripts with the `pipefail` option set to remove the possibility of incorrectly passing tests.

Connects https://github.com/pelias/pelias/issues/744
Connects https://github.com/pelias/pelias/issues/745