### PR TITLE
feat(test): Run tests in dedicated script to catch errors

### DIFF
--- a/bin/funcs
+++ b/bin/funcs
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# run tests with pipefail to avoid false passes
+# see https://github.com/pelias/pelias/issues/744
+set -euo pipefail
+
+MOCK_LIBPOSTAL=true node test/_func.js | npx tap-spec

--- a/bin/units
+++ b/bin/units
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# run tests with pipefail to avoid false passes
+# see https://github.com/pelias/pelias/issues/744
+set -euo pipefail
+
+MOCK_LIBPOSTAL=true node test/_unit.js | npx tap-spec

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "main": "index.js",
   "scripts": {
     "test": "npm run units",
-    "funcs": "MOCK_LIBPOSTAL=true node test/_func.js | tap-spec",
-    "units": "MOCK_LIBPOSTAL=true node test/_unit.js | tap-spec",
+    "funcs": "./bin/funcs",
+    "units": "./bin/units",
     "travis": "npm test && npm run funcs",
     "lint": "jshint .",
     "validate": "npm ls",


### PR DESCRIPTION
The way we were running our unit tests does not catch fatal errors in the unit test run, even though they return non-zero status codes.

By using a dedicated script to run the tests, with the `pipefail` option, we can catch them.

Connects https://github.com/pelias/pelias/issues/744