### PR TITLE
Support read-only root filesystem in Docker containers

### DIFF
--- a/bin/download-tiger
+++ b/bin/download-tiger
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec node script/js/update_tiger.js

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -5,4 +5,4 @@ export PBF2JSON_FILE=$(ls ${OSMPATH}/*.osm.pbf | head -n 1)
 export POLYLINE_FILE=$(ls ${POLYLINEPATH}/*.0sv | head -n 1)
 
 # run the build
-npm run build
+exec ./script/build.sh

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "travis": "npm test && npm run funcs",
     "lint": "jshint .",
     "validate": "npm ls",
-    "download-tiger": "node script/js/update_tiger.js",
+    "download-tiger": "./bin/download-tiger",
     "build": "./script/build.sh"
   },
   "repository": {


### PR DESCRIPTION
By using dedicated scripts to start downloads and the interpolation service, we can avoid several issues encountered in Docker containers:
- `npm` does not pass signals, so by avoiding `npm start` and using `exec` to minimize extra "layers" of shell scripts, we can ensure our containers stop quickly when told to stop.
- `npm` requires write access to the root filesystem. We wish to avoid that requirement.

For this project, we also use `exec` in `docker_build.sh` to avoid a call to `npm`.

Connects https://github.com/pelias/pelias/issues/745