### PR TITLE
feat(tiger): Download nothing instead of all if no config present

### DIFF
--- a/script/js/update_tiger.js
+++ b/script/js/update_tiger.js
@@ -3,7 +3,7 @@ const async = require('async');
 const path = require('path');
 const fs = require('fs-extra');
 const unzip = require('unzip');
-const logger = require('pelias-logger').get('update_tiger');
+const logger = require('pelias-logger').get('interpolation(TIGER)');
 const config = require('pelias-config').generate();
 const _ = require('lodash');
 
@@ -11,7 +11,13 @@ const _ = require('lodash');
 let TARGET_DIR = _.get(config, 'imports.interpolation.download.tiger.datapath', './data/downloads');
 let STATES = _.get(config, 'imports.interpolation.download.tiger.states', []);
 
+if (_.isUndefined(_.get(config, 'imports.interpolation.download.tiger'))) {
+  logger.warn('pelias.json has no \'imports.interpolation.download.tiger\' section, quitting');
+  process.exit(0);
+}
+
 if (_.isEmpty(STATES)) {
+  logger.info('downloading all TIGER data');
   STATES = [ {state_code: '', county_code: ''} ];
 }
 


### PR DESCRIPTION
Many people wish to skip the interpolation TIGER download in projects such as `pelias/docker`, where the interpolation engine is configured to run by default.

Currently, there is no way to tell the downloader to skip downloading _any_ data. This PR makes it so that if there is no `imports.interpolation.download.tiger` section at all in `pelias.json`, the downloader will take no action.

An empty object for that key in `pelias.json` will still download all TIGER data.

Connects https://github.com/pelias/docker/issues/5