### PR TITLE
improved support for Spanish addresses

### DIFF
--- a/lib/analyze.js
+++ b/lib/analyze.js
@@ -73,6 +73,13 @@ function housenumber( num ){
   // see: https://eastasiastudent.net/china/mandarin/postal-address/
   number = number.replace(/(号|號|室|宅|楼)/g, '');
 
+  // only use the first part of a comma delimited string such as '27, 2º, 4ª'
+  number = number.split(',')[0].trim();
+
+  // do not merge adjacent numerals delimted by whitespace
+  // see: https://github.com/pelias/interpolation/issues/199
+  if (/[0-9]\s+[0-9]/.test(number) ){ number = number.split(/\s+/)[0]; }
+
   // remove spaces from housenumber. eg: '2 A' -> '2A'
   number = number.replace(/\s+/g, '').toLowerCase();
 

--- a/test/lib/analyze.js
+++ b/test/lib/analyze.js
@@ -62,6 +62,8 @@ module.exports.analyze.housenumber = function(test) {
     t.false(isNaN(analyze.housenumber('1434 UNIT #B')), 'remove common english label "unit"');
     t.false(isNaN(analyze.housenumber('1434 SUITE #B')), 'remove common english label "suite"');
     t.false(isNaN(analyze.housenumber('158號')), 'remove common mandarin label');
+    t.false(isNaN(analyze.housenumber('240 4t')), 'remove unknown numeric component');
+    t.false(isNaN(analyze.housenumber('27, 2º, 4ª')), 'spanish address');
     t.end();
   });
 
@@ -171,6 +173,17 @@ module.exports.analyze.housenumber = function(test) {
   });
   test('housenumber: removes common mandarin labels', function(t) {
     t.equal(analyze.housenumber('158號'), 158.00);
+    t.end();
+  });
+
+  // spanish housenumbers
+  // https://www.openstreetmap.org/node/672948135
+  test('housenumber: 240 4t', function (t) {
+    t.equal(analyze.housenumber('240 4t'), 240);
+    t.end();
+  });
+  test('housenumber: 27, 2º, 4ª ', function (t) {
+    t.equal(analyze.housenumber('27, 2º, 4ª'), 27);
     t.end();
   });
 };


### PR DESCRIPTION
support for the following house number formats:
- `240 4t`
- `27, 2º, 4ª`

resolves #199