### PR TITLE
remove diacritics for non-latin languages

### DIFF
--- a/lib/analyze.js
+++ b/lib/analyze.js
@@ -61,8 +61,12 @@ function housenumber( num ){
   // still not a valid string?
   if( 'string' !== typeof num ){ return NaN; }
 
+  // normalize string diacritics
+  // https://stackoverflow.com/a/37511463
+  var number = num.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+
   // replace fractions, eg: '1/2' with british style character suffices.
-  var number = num.replace(' 1/4', '¼')
+  number = number.replace(' 1/4', '¼')
                   .replace(' 1/2', '½')
                   .replace(' 3/4', '¾');
 

--- a/test/lib/analyze.js
+++ b/test/lib/analyze.js
@@ -186,6 +186,12 @@ module.exports.analyze.housenumber = function(test) {
     t.equal(analyze.housenumber('27, 2º, 4ª'), 27);
     t.end();
   });
+
+  // non-latin apartment letters
+  test('housenumber: 18Č', function (t) {
+    t.equal(analyze.housenumber('18Č'), 18.09);
+    t.end();
+  });
 };
 module.exports.analyze.housenumberFloatToString = function(test) {
   test('housenumberFloatToString: invalid', function(t) {


### PR DESCRIPTION
handle non-latin apartment characters by first normalizing them to latin (eg. `18Č`)
as mentioned in https://github.com/pelias/interpolation/issues/195