### PR TITLE
build.sh: allow ENV PBF2JSON_BIN to be set

### DIFF
--- a/script/build.sh
+++ b/script/build.sh
@@ -12,7 +12,7 @@ export LC_ALL=en_US.UTF-8;
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd );
 
 export TIMESTAMP=$(date +"%m-%d-%Y-%H:%M:%S");
-export PBF2JSON_BIN="$DIR/../node_modules/pbf2json/build/pbf2json.linux-x64";
+export PBF2JSON_BIN="${PBF2JSON_BIN:-"$DIR/../node_modules/pbf2json/build/pbf2json.linux-x64"}";
 
 # location of data files
 export WORKINGDIR="${WORKINGDIR:-"/mnt/pelias"}";


### PR DESCRIPTION
This change allows users to run build.sh with a custom PBF2JSON_BIN ENV, i.e. to work around issue
pelias/interpolation#73.