### PR TITLE
feat(Dockerfile): Update to a modern version of awk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM pelias/libpostal_baseimage
 
 # dependencies
 RUN apt-get update && \
-    apt-get install -y python sqlite3 gdal-bin lftp unzip pigz time && \
+    apt-get install -y python sqlite3 gdal-bin lftp unzip pigz time gawk && \
     rm -rf /var/lib/apt/lists/*
 
 # --- pbf2json ---


### PR DESCRIPTION
Ubuntu comes with an extremely old (circa 1996) version of awk which
apparently has some performance regressions.

By updating to the latest version we can mitigate _some_ of the
slowness of building interpolation database.

Connects https://github.com/pelias/interpolation/issues/211