### PR TITLE
delete npm unzipper, replace with GDAL virtual filesystem

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,7 @@
     "sqlite3": "^4.0.0",
     "superagent": "^5.1.0",
     "through2": "^3.0.0",
-    "through2-batch": "^1.0.1",
-    "unzipper": "^0.10.9"
+    "through2-batch": "^1.0.1"
   },
   "devDependencies": {
     "jshint": "^2.9.3",

--- a/script/conflate_tiger.sh
+++ b/script/conflate_tiger.sh
@@ -51,18 +51,18 @@ rm -f $PROC_STDOUT $PROC_STDERR $PROC_CONFERR;
 
 # download path of tiger files (use default unless param is supplied)
 TIGERPATH=${TIGERPATH:-"$WORKINGDIR/data/tiger"};
-# ensure shapefiles directory exists
-[ -d "$TIGERPATH/shapefiles" ] || mkdir -p "$TIGERPATH/shapefiles";
+# ensure downloads directory exists
+[ -d "$TIGERPATH/downloads" ] || mkdir -p "$TIGERPATH/downloads";
 
-# recurse through filesystem listing all .shx file names
+# recurse through filesystem listing all .zip file names
 # some county zip packages are missing .shx which causes the ogr2ogr script to fail
-find "$TIGERPATH/shapefiles" -type f -iname "*.shx" -print0 |\
+find "$TIGERPATH/downloads" -type f -iname "*.zip" -print0 |\
   while IFS= read -r -d $'\0' filename; do
 
     # echo filename to stderr
     >&2 echo $(date -u) "$filename";
 
-    ogr2ogr -f GeoJSON -t_srs crs:84 /vsistdout/ "$filename" |\
+    ogr2ogr -f GeoJSON -t_srs crs:84 /vsistdout/ /vsizip/$filename |\
       node --max-old-space-size=8192 $DIR/../cmd/tiger.js $ADDRESS_DB $STREET_DB 1>>$PROC_STDOUT 2>>$PROC_STDERR;
 
   done;

--- a/script/update_tiger.sh
+++ b/script/update_tiger.sh
@@ -10,7 +10,6 @@ TIGERPATH=${TIGERPATH:-"$WORKINGDIR/data/tiger"};
 
 # create directory if it doesn't exist
 mkdir -p $TIGERPATH/downloads;
-mkdir -p $TIGERPATH/shapefiles;
 
 # ensure lftp exists and is executable
 if [[ ! -f /usr/bin/lftp || ! -x /usr/bin/lftp ]]; then
@@ -24,18 +23,3 @@ lftp <<-SCRIPT
   mirror -e -n -r --parallel=20 --ignore-time /geo/tiger/TIGER2016/ADDRFEAT/ $TIGERPATH/downloads
   exit
 SCRIPT
-
-# ensure unzip exists and is executable
-if [[ ! -f /usr/bin/unzip || ! -x /usr/bin/unzip ]]; then
-  echo "unzip not installed on system";
-  exit 1;
-fi
-
-# delete directory contents
-cd $TIGERPATH/shapefiles;
-find -mindepth 1 -maxdepth 1 -print0 | xargs -0 rm -rf;
-
-# extract all the shapefiles from downloads in to dir
-for file in $TIGERPATH/downloads/*.zip; do
-  unzip "$file" -d $TIGERPATH/shapefiles;
-done


### PR DESCRIPTION
I'm getting tired of seeing `npm unzip` issues, so 👋 bye bye module 👋 

Many years ago when I wrote this code I didn't know about [GDAL virtual filesystems](https://gdal.org/user/virtual_file_systems.html) and assumed that zip files are easy, and streamable, which it turns out they aren't 🤷‍♂ 

This PR greatly simplifies the code by downloading the `.zip` files and then... wait for it... **not** decompressing them 😱 
The only process reading these files is `ogr2ogr` and it'll just as happily read ZIP files as it would the SHP files.

Good news is we can delete the npm module and also the `shapefiles` directory in the process.