### PR TITLE
logger performance warning

### DIFF
--- a/cmd/server.js
+++ b/cmd/server.js
@@ -1,15 +1,12 @@
 
-var express = require('express'),
-    directory = require('serve-index'),
-    polyline = require('@mapbox/polyline'),
-    search = require('../api/search'),
-    extract = require('../api/extract'),
-    street = require('../api/street'),
-    near = require('../api/near'),
-    pretty = require('../lib/pretty'),
-    analyze = require('../lib/analyze'),
-    project = require('../lib/project'),
-    proximity = require('../lib/proximity');
+const express = require('express');
+const polyline = require('@mapbox/polyline');
+const search = require('../api/search');
+const extract = require('../api/extract');
+const street = require('../api/street');
+const near = require('../api/near');
+const pretty = require('../lib/pretty');
+const analyze = require('../lib/analyze');
 
 const morgan = require( 'morgan' );
 const logger = require('pelias-logger').get('interpolation');
@@ -38,6 +35,15 @@ var conn = {
 };
 
 function log() {
+  const verboseLevels = ['info', 'debug'];
+  const logLevel = _.get(logger, 'transports.console.level', '');
+  if (process.stdout.isTTY && verboseLevels.includes(logLevel)){
+    logger.warn(
+      `usage of verbose logging levels (${verboseLevels.join(',')})` +
+      `where stdout is a TTY can have a severe negative performance impact.`
+    );
+  }
+
   morgan.token('url', (req, res) => {
     // if there's a DNT header, just return '/' as the URL
     if (['DNT', 'dnt', 'do_not_track'].some(header => _.has(req.headers, header))) {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "jsftp": "^2.0.0",
     "lodash": "^4.17.4",
     "morgan": "^1.9.0",
-    "node-postal": "^1.0.0",
+    "node-postal": "https://github.com/imothee/node-postal.git",
     "pbf2json": "^6.4.0",
     "pelias-config": "^4.0.0",
     "pelias-logger": "^1.2.1",


### PR DESCRIPTION
Usage of the `info` or `debug` level logging when `stdout` is a `TTY` results in a ~25% performance hit.
This PR simply adds a warning so developers are aware.

```bash
stdout is a TTY
    iteration_duration.........: avg=71.83ms min=15.43ms med=70.58ms max=135.37ms p(90)=86.29ms p(95)=92.87ms
    iterations.................: 10000  1388.112538/s

stdout is /dev/null
    iteration_duration.........: avg=55.19ms min=23.44ms med=54.81ms max=81.28ms p(90)=62.97ms p(95)=65.49ms
    iterations.................: 10000  1806.935143/s
```