### PR TITLE
feat(package): use node-postal module compatible with node12

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "jsftp": "^2.0.0",
     "lodash": "^4.17.4",
     "morgan": "^1.9.0",
-    "node-postal": "^1.0.0",
+    "node-postal": "imothee/node-postal#6d0b00f68a",
     "pbf2json": "^6.4.0",
     "pelias-config": "^4.0.0",
     "pelias-logger": "^1.2.1",


### PR DESCRIPTION
Extracted from other recent PRs. This allows us to support actually running the interpolation service on Node.js 12

If we end up merging something like #146 which unbundles the libpostal service from this repo, then we won't not need this any more, but it's a small enough change that it's worth it.

Connects https://github.com/pelias/pelias/issues/800