### PR TITLE
feat(deps): Remove fs-extra module

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "cli-table3": "^0.5.0",
     "csv-parse": "^4.4.6",
     "express": "^4.14.0",
-    "fs-extra": "^8.0.0",
     "jsftp": "^2.0.0",
     "lodash": "^4.17.4",
     "morgan": "^1.9.0",

--- a/script/js/update_tiger.js
+++ b/script/js/update_tiger.js
@@ -1,6 +1,6 @@
 const async = require('async');
 const path = require('path');
-const fs = require('fs-extra');
+const fs = require('fs');
 const logger = require('pelias-logger').get('interpolation(TIGER)');
 const config = require('pelias-config').generate();
 const _ = require('lodash');
@@ -84,7 +84,7 @@ function downloadFilteredFiles(context, callback) {
   context.downloadsDir = path.join(TARGET_DIR, 'downloads');
 
   // ensure directories exist
-  fs.ensureDirSync(context.downloadsDir);
+  fs.mkdirSync(context.downloadsDir, { recursive: true });
 
   // ensure directories are writable
   fs.accessSync(context.downloadsDir, fs.constants.R_OK | fs.constants.W_OK);


### PR DESCRIPTION
In this project, we only use the fs-extra package for its `mkdir -p` style convenience wrapper, which can now easily be done with the stock fs module.

This change removes usage of the fs-extra module and replaces it withthe native recursive option.

Closes https://github.com/pelias/interpolation/pull/251