### PR TITLE
set journal_mode=MEMORY for performance

### DIFF
--- a/query/attach.js
+++ b/query/attach.js
@@ -1,0 +1,12 @@
+
+module.exports = function( db, path, name, done ){
+
+  var sql = 'ATTACH DATABASE \'$path\' as \'$name\';';
+  sql = sql.replace( '$path', path );
+  sql = sql.replace( '$name', name );
+
+  db.serialize(function(){
+    db.run(sql);
+    db.wait(done);
+  });
+};

--- a/query/configure.js
+++ b/query/configure.js
@@ -6,6 +6,6 @@ module.exports = ( db ) => {
   db.exec('PRAGMA main.page_size=4096;'); // (default: 1024)
   db.exec('PRAGMA main.cache_size=-2000;'); // (default: -2000, 2GB)
   db.exec('PRAGMA main.synchronous=OFF;');
-  db.exec('PRAGMA main.journal_mode=OFF;');
+  db.exec('PRAGMA main.journal_mode=MEMORY;'); // better-sqlite3 does not support 'OFF'
   db.exec('PRAGMA main.temp_store=MEMORY;');
 };


### PR DESCRIPTION
As per https://github.com/pelias/placeholder/pull/180 the `better-sqlite3` module [doesn't support `journal_mode=OFF`](https://github.com/JoshuaWise/better-sqlite3/pull/380).

I'm going to run a full planet build using this setting before bringing it out of `DRAFT`.

The functional tests take 6/8 the time they did before, not a very trustworthy benchmark but may be indicative of a significant performance improvement at import time, so this could bring the build down from ~4 days to ~3 🎉 