### PR TITLE
update nearby endpoint to return projected point-on-line

### DIFF
--- a/cmd/server.js
+++ b/cmd/server.js
@@ -155,7 +155,8 @@ app.get('/street/near/geojson', function( req, res ){
             'id': o.street.id,
             'name': Array.isArray( o.street.name ) ? o.street.name[0] : o.street.name,
             'polyline': o.street.line,
-            'distance': ( Math.floor(( o.proj.dist || 0 ) * 1000000 ) / 1000000 )
+            'distance': ( Math.floor(( o.proj.dist || 0 ) * 1000000 ) / 1000000 ),
+            'projection': o.proj.point
           },
           'geometry': {
             'type': 'LineString',


### PR DESCRIPTION
This PR adds a new property `projection` to the `nearby` endpoint which returns the projected point-on-line.

<img width="246" alt="Screenshot 2020-06-30 at 17 13 07" src="https://user-images.githubusercontent.com/738069/86143807-30668380-baf5-11ea-8a7f-04c98d4db6e8.png">

