### PR TITLE
Add host address env var override and update README

### DIFF
--- a/cmd/server.js
+++ b/cmd/server.js
@@ -11,9 +11,11 @@ const morgan = require( 'morgan' );
 const logger = require('pelias-logger').get('interpolation');
 const through = require( 'through2' );
 const _ = require('lodash');
+const util = require( 'util' );
 
-// optionally override port using env var
+// optionally override port/host using env var
 const PORT = process.env.PORT || 3000;
+const HOST = process.env.HOST || undefined;
 
 // help text
 if( process.argv.length !== 4 ){
@@ -218,10 +220,10 @@ app.use('/demo', express.static('demo'));
 // app.use('/builds', express.static('/data/builds'));
 // app.use('/builds', directory('/data/builds', { hidden: false, icons: false, view: 'details' }));
 
-app.listen( PORT, function() {
+app.listen( PORT, HOST, function() {
 
   // force loading of libpostal
   analyze.street( 'test street' );
 
-  console.log( 'server listening on port', PORT );
+  console.log(util.format( 'server listening on %s:%s', HOST || '0.0.0.0', PORT ));
 });

--- a/readme.md
+++ b/readme.md
@@ -219,12 +219,20 @@ note: the lat/lon values you provide are in order to disambiguate the street, th
 ### Start the web server
 > run a web server which exposes the search APIs via an HTTP interface
 
-note: you can set an environment variable named 'PORT' to change the port number.
 ```bash
 ./interpolate server address.db street.db
 
 server listening on port 3000
 ```
+
+#### Configuration via Environment Variables
+
+The API supports additional environment variables that affect its operation:
+
+| Environment Variable | Default | Description |
+| -------------------- | ------- | ----------- |
+| `HOST` | `undefined` | The network address that interpolation will bind to. Defaults to whatever the current Node.js default is, which is currently to listen on `0.0.0.0` (all interfaces). See the [Node.js Net documentation](https://nodejs.org/api/net.html#net_server_listen_port_host_backlog_callback) for more information. |
+| `PORT` | `3000` | The TCP port that interpolation will use for incoming network connections |
 
 ### GET /search/{format}
 > search the db for an address, return an interpolated value if an exact match does not exist


### PR DESCRIPTION
---
#### Here's the reason for this change :rocket:

* Added support for overriding the default network address to bind to via the HOST environment variable, in line with (almost) all of the other Pelias services.

---
#### Here's what actually got changed :clap:


* Update `cmd/server.js` adding support for the HOST env var and passing this to `app.listen()`
* Small update to `README.md` documenting this

---
#### Here's how others can test the changes :eyes:

Without `HOST` defined ...

```
PORT=4300 ./interpolate server address.db street.db
server listening on 0.0.0.0:4300
```

```
sudo lsof -i -P -n | grep LISTEN | grep 4300
node      92897          pelias   24u  IPv6 512879      0t0  TCP *:4300 (LISTEN)
```

With `HOST` defined ...

```
HOST=127.0.0.1 PORT=4300 ./interpolate server address.db street.db
server listening on 127.0.0.1:4300
```

```
sudo lsof -i -P -n | grep LISTEN | grep 4300
node      92917          pelias   24u  IPv4 523764      0t0  TCP 127.0.0.1:4300 (LISTEN)
```
