### PR TITLE
change TIGER data mirror to GeocodeEarth CDN

### DIFF
--- a/script/js/adapter/CensusS3Mirror.js
+++ b/script/js/adapter/CensusS3Mirror.js
@@ -6,8 +6,8 @@ const conform = /^tl_2016_(\d{5})_addrfeat\.zip$/;
 
 class CensusS3Mirror {
   constructor() {
-    this.host = 'https://census-backup.s3.amazonaws.com';
-    this.prefix = '/tiger/2016/ADDRFEAT';
+    this.host = 'https://data.geocode.earth';
+    this.prefix = '/uscensus/geo/tiger/TIGER2016/ADDRFEAT';
   }
   list(pattern, cb) {
 


### PR DESCRIPTION
Our existing TIGER HTTP mirror is not longer active (https://census-backup.s3.amazonaws.com/).
I've synced the data to the GeocodeEarth CDN so we don't have issues in the future.

I've uploaded both the `2016` and `2019` files for when we decide to upgrade.
- https://data.geocode.earth/uscensus/geo/tiger/TIGER2016/ADDRFEAT/index.html
- https://data.geocode.earth/uscensus/geo/tiger/TIGER2019/ADDRFEAT/index.html