### PR TITLE
Upgrade better-sqlite3 to latest version (v7.4.3)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,6 +10,7 @@ jobs:
         node-version:
           - 12.x
           - 14.x
+          - 16.x
     steps:
       - uses: actions/checkout@v2
       - name: 'Install node.js ${{ matrix.node-version }}'

--- a/api/near.js
+++ b/api/near.js
@@ -12,7 +12,7 @@ function setup( streetDbPath ){
 
   // connect to db
   // @todo: this is required as the query uses the 'street.' prefix for tables
-  const db = new Database('/tmp/path', { memory: true });
+  const db = new Database(':memory:');
 
   // attach street database
   db.exec(`ATTACH DATABASE '${streetDbPath}' as 'street'`);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@mapbox/polyline": "^1.0.0",
     "async": "^3.1.0",
-    "better-sqlite3": "github:missinglink/better-sqlite3#unsafe_mode",
+    "better-sqlite3": "^7.4.3",
     "cheerio": "^1.0.0-rc.3",
     "cli-table3": "^0.6.0",
     "csv-parse": "^4.4.6",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "license": "MIT",
   "main": "index.js",
   "scripts": {
-    "postinstall": "npm install --build-from-source missinglink/better-sqlite3#unsafe_mode",
     "test": "npm run units",
     "funcs": "./bin/funcs",
     "units": "./bin/units",


### PR DESCRIPTION
this PR matches a bunch of similar ones in other repos where the version of `better-sqlite3` has been upgraded to the latest version, this removes the need to link to my branch and also adds support for recent versions of nodejs.

closes: https://github.com/pelias/interpolation/pull/257, but may require [enabling unsafe mode](https://github.com/JoshuaWise/better-sqlite3/blob/master/docs/unsafe.md)