### PR TITLE
Use new syntax to enable sqlite3 'unsafe mode'

### DIFF
--- a/api/vertices.js
+++ b/api/vertices.js
@@ -7,7 +7,8 @@ const query = requireDir('../query');
 function vertices(addressDbPath, streetDbPath, done){
 
   // connect to db
-  const db = new Database(addressDbPath, { unsafe: true });
+  const db = new Database(addressDbPath);
+  db.unsafeMode();
 
   query.configure(db); // configure database
   query.tables.address(db); // create tables only if not already created


### PR DESCRIPTION
The 'vertex interpolation' step of the interpolation build both reads and writes to the same sqlite3 database. This requires [unsafe mode](https://github.com/JoshuaWise/better-sqlite3/blob/master/docs/unsafe.md) in `better-sqlite3` to be enabled.

We upgraded `better-sqlite3` to a new version in https://github.com/pelias/interpolation/pull/268, but that version came with a new way to enable unsafe mode.

This change makes the correct call to `better-sqlite3` so that unsafe mode is properly set.

Fixes https://github.com/pelias/docker/issues/269
Connects https://github.com/pelias/interpolation/issues/272