### PR TITLE
feat(deps): upgrade node-postal

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "jsftp": "^2.0.0",
     "lodash": "^4.17.4",
     "morgan": "^1.9.0",
-    "node-postal": "imothee/node-postal#6d0b00f68a",
+    "node-postal": "^1.1.1",
     "pbf2json": "^6.4.0",
     "pelias-config": "^4.0.0",
     "pelias-logger": "^1.2.1",


### PR DESCRIPTION
this PR was generated with the following command:

```bash
npm i node-postal@latest --save
```

previously we were linking to an old git branch, since https://github.com/openvenues/node-postal/pull/25 & https://github.com/openvenues/node-postal/issues/28 we should be fine to return to a semver versioned npm package 🎉 