### PR TITLE
use better-sqlite "unsafe" mode for all import APIs

### DIFF
--- a/api/oa.js
+++ b/api/oa.js
@@ -8,6 +8,7 @@ function oa(dataStream, addressDbPath, streetDbPath, done){
 
   // connect to db
   const db = new Database(addressDbPath);
+  db.unsafeMode(true);
 
   query.configure(db); // configure database
   query.tables.address(db); // create tables only if not already created

--- a/api/osm.js
+++ b/api/osm.js
@@ -8,6 +8,7 @@ function osm(dataStream, addressDbPath, streetDbPath, done){
 
   // connect to db
   const db = new Database(addressDbPath);
+  db.unsafeMode(true);
 
   query.configure(db); // configure database
   query.tables.address(db); // create tables only if not already created

--- a/api/polyline.js
+++ b/api/polyline.js
@@ -8,6 +8,7 @@ function polyline(dataStream, streetDbPath, done){
 
   // connect to db
   const db = new Database(streetDbPath);
+  db.unsafeMode(true);
 
   query.configure(db); // configure database
   query.tables.street(db, true); // reset database and create tables

--- a/api/tiger.js
+++ b/api/tiger.js
@@ -8,6 +8,7 @@ function tiger(dataStream, addressDbPath, streetDbPath, done){
 
   // connect to db
   var db = new Database( addressDbPath );
+  db.unsafeMode(true);
 
   query.configure(db); // configure database
   query.tables.address(db); // create tables only if not already created

--- a/api/vertices.js
+++ b/api/vertices.js
@@ -8,7 +8,7 @@ function vertices(addressDbPath, streetDbPath, done){
 
   // connect to db
   const db = new Database(addressDbPath);
-  db.unsafeMode();
+  db.unsafeMode(true);
 
   query.configure(db); // configure database
   query.tables.address(db); // create tables only if not already created


### PR DESCRIPTION
following on from https://github.com/pelias/interpolation/pull/273 this PR uses the `better-sqlite3` `unsafe` mode for all import APIs.

the advantage of this (mentioned in https://github.com/pelias/interpolation/issues/272) is improved performance and therefore reduced build times, particularly noticeable on MacOS using Docker (because of the additional I/O which operates through an FS adapter on Mac):

I found a ~19% improvement in import duration:

```bash
# build portland-metro on master:
pelias prepare interpolation  0.74s user 0.34s system 0% cpu 37:13.12 total

# build portland-metro on this branch
pelias prepare interpolation  0.67s user 0.26s system 0% cpu 29:44.93 total
```

closes https://github.com/pelias/interpolation/issues/272 