### PR TITLE
superfluous trailing slash in TIGERPATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ ENV POLYLINEPATH '/data/polylines'
 ENV OAPATH '/data/openaddresses'
 
 # location of TIGER data
-ENV TIGERPATH '/data/tiger/'
+ENV TIGERPATH '/data/tiger'
 
 # root location of data files
 ENV WORKINGDIR '/data'


### PR DESCRIPTION
This PR removes the superfluous trailing slash in `TIGERPATH` which causes a double slash `//` to be rendered in the logs but doesn't serve any function.

```bash
# master
- conflating tiger
Wed Oct 20 14:25:13 UTC 2021 /data/tiger//downloads/tl_2021_41005_addrfeat.zip
Wed Oct 20 14:26:47 UTC 2021 /data/tiger//downloads/tl_2021_41047_addrfeat.zip

# this branch
- conflating tiger
Wed Oct 20 14:56:40 UTC 2021 /data/tiger/downloads/tl_2021_41005_addrfeat.zip
Wed Oct 20 14:58:17 UTC 2021 /data/tiger/downloads/tl_2021_41047_addrfeat.zip
```