### PR TITLE
feat(logging): reduce log verbosity

### DIFF
--- a/stream/oa/convert.js
+++ b/stream/oa/convert.js
@@ -39,7 +39,7 @@ function streamFactory(){
       address.setCoord({ lon: csv.LON, lat: csv.LAT });
     }
     catch( e ){
-      console.error( 'invalid csv row', e );
+      console.error( 'invalid csv row', e.message );
       console.error( csv );
       return next();
     }


### PR DESCRIPTION
simple, partial fix for the issue mentioned in https://github.com/pelias/interpolation/issues/278
this PR simply changes the logger to write *only* the error message and not the whole stack.

the log files contain many entries such as the one below, the stack itself isn't useful and the corresponding line number can be found easily with `git grep 'invalid csv row Error'` as its the only occurrence in the repo.

I expect that this minor change will significantly reduce the log size, at least for addresses with an empty `NUMBER` or `STREET` field.

```bash
invalid csv row Error: invalid street
    at Address.setStreet (/code/interpolation/lib/Address.js:71:11)
    at DestroyableTransform._transform (/code/interpolation/stream/oa/convert.js:37:15)
    at DestroyableTransform.Transform._read (/code/interpolation/node_modules/readable-stream/lib/_stream_transform.js:184:10)
    at DestroyableTransform.Transform._write (/code/interpolation/node_modules/readable-stream/lib/_stream_transform.js:172:83)
    at doWrite (/code/interpolation/node_modules/readable-stream/lib/_stream_writable.js:428:64)
    at writeOrBuffer (/code/interpolation/node_modules/readable-stream/lib/_stream_writable.js:417:5)
    at DestroyableTransform.Writable.write (/code/interpolation/node_modules/readable-stream/lib/_stream_writable.js:334:11)
    at Parser.ondata (_stream_readable.js:718:22)
    at Parser.emit (events.js:314:20)
    at addChunk (_stream_readable.js:297:12)
{
  LON: '22.9419749',
  LAT: '40.5794481',
  NUMBER: '1',
  STREET: '',
  UNIT: '',
  CITY: '',
  DISTRICT: '',
  REGION: '',
  POSTCODE: '',
  ID: '',
  HASH: 'gr/b/municipality_of_kalamaria:a31ca0d87194db14'
}
```

there's still way more we can do to mitigate https://github.com/pelias/interpolation/issues/278, I suspect that developers rarely even read these logs, so maybe configuring the verbosity and only enabling high verbosity during local development would be preferable.