### PR TITLE
demo: use solid markers

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -309,7 +309,7 @@
       var color = fp['marker-color'] || '7e7e7e';
       color = color.replace('#', '');
 
-      var url = 'http://a.tiles.mapbox.com/v3/marker/' +
+      var url = 'http://a.tiles.mapbox.com/v2/marker/' +
             'pin-' +
             // Internet Explorer does not support the `size[0]` syntax.
             size.charAt(0) + symbol + '+' + color +


### PR DESCRIPTION
at some point the marker images used for the demo changed to include an inner white circle which makes reading the house numbers very difficult.

<img width="209" alt="Screenshot 2021-11-01 at 20 29 35" src="https://user-images.githubusercontent.com/738069/139729927-e4ace82a-ef6d-40f3-b4e5-073053af6470.png">

this PR simply changes the image version number from `3->2` which resolves the issue and reverts to the previous style:

<img width="207" alt="Screenshot 2021-11-01 at 20 29 30" src="https://user-images.githubusercontent.com/738069/139729984-8b785ba8-0176-4c9b-ac46-818023998aa2.png">
