### PR TITLE
Increase Leaflet `maxZoom` to 25

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -36,6 +36,7 @@
     // Create a basic Leaflet map
     var map = L.map('map', { zoomControl:false });
     L.tileLayer('//{s}.tile.jawg.io/jawg-terrain/{z}/{x}/{y}.png?access-token=t6fAKnvaPdPCucraY88YwlKjBfUHqBMvvZBIWlcp1Z9Z5FVtA02uWo6Dc9DGB2JO', {
+      maxZoom: 25,
       attribution: 'Map &copy; <a href="http://jawg.io" target="_blank" class="jawg-attrib"><b>Jawg</b>Maps</a>, Map data &copy; <a href="https://www.openstreetmap.org/copyright" target="_blank" class="osm-attrib">OpenStreetMap contributors</a>'
     }).addTo(map);
 


### PR DESCRIPTION
Sometimes its useful to be able to zoom in quite a bit when inspecting the exact location of addresses in the demo.

The Leaflet default is to max out at zoom 18. This increases that value to 25, quite a bit closer.