### PR TITLE
fix(Docker): Use multi-stage build to handle node-postal dependencies 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,41 @@
+# builder image for node-postal (requires c++ toolchain and python3)
+FROM pelias/libpostal_baseimage as builder
+
+ENV WORKDIR /code/pelias/interpolation
+WORKDIR ${WORKDIR}
+
+# install dependencies for node-postal build
+RUN apt-get update && apt-get install -y python3 build-essential
+
+COPY --chown=pelias ./package.json ${WORKDIR}
+
+RUN npm install
+
 # base image
 FROM pelias/libpostal_baseimage
 
-# dependencies
+# interpolation dependencies
 RUN apt-get update && \
-    apt-get install -y python sqlite3 gdal-bin lftp unzip pigz time gawk && \
+    apt-get install -y sqlite3 gdal-bin lftp unzip pigz time gawk && \
     rm -rf /var/lib/apt/lists/*
 
 # change working dir
 ENV WORKDIR /code/pelias/interpolation
 WORKDIR ${WORKDIR}
 
-# de-escalate to non-root user
 RUN chown -R pelias /code
+
+# de-escalate to non-root user
 USER pelias
 
-# copy package.json first to prevent npm install being rerun when only code changes
-COPY --chown=pelias ./package.json ${WORKDIR}
+# copy npm dependencies from builder image
+COPY --chown=pelias --from=builder $WORKDIR/node_modules node_modules/
 
-# install npm dependencies
-RUN npm install
-
-# add the rest of the code
+# add the code
 COPY --chown=pelias . ${WORKDIR}
+
+# run a quick test that libpostal and node-postal are fully working
+RUN node test/test_libpostal.js
 
 # run tests
 RUN npm test && npm run funcs && rm -rf test

--- a/test/test_libpostal.js
+++ b/test/test_libpostal.js
@@ -1,0 +1,7 @@
+const postal = require('node-postal');
+
+// Expansion API
+ postal.expand.expand_address('V XX Settembre, 20');
+
+// Parser API
+postal.parser.parse_address('Barboncino 781 Franklin Ave, Crown Heights, Brooklyn, NY 11238');


### PR DESCRIPTION
The [node-postal](https://github.com/openvenues/node-postal) NPM module requires a full C++ compiler toolchain _and_ python3 to install. After pelias/docker-baseimage#23 and pelias/docker-libpostal_baseimage#5 this toolchain is no longer present in our Docker baseimage.

This PR uses a Docker multi-stage build to build _just_ the NPM modules required by the interpolation service while a C++ toolchain is present.

The `node_modules` directory can then be copied to the final image without needing a C++ toolchain or python to be present.

In addition to saving some space in the final image, this fixes issues people were having with our Docker images, since `node-postal` wasn't functional.

Fixes pelias/docker#271