### PR TITLE
Upgrade to node-postal 1.1.2 for Node.js 16 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "jsftp": "^2.0.0",
     "lodash": "^4.17.4",
     "morgan": "^1.9.0",
-    "node-postal": "^1.1.1",
+    "node-postal": "^1.1.2",
     "pbf2json": "^6.4.0",
     "pelias-config": "^4.0.0",
     "pelias-logger": "^1.2.1",


### PR DESCRIPTION
This PR explicitly upgrades the dependency on `node-postal` to require version 1.1.2 or greater.

That version adds support for Node.js 16 via https://github.com/openvenues/node-postal/pull/37.

I did some testing and can confirm that when pinned to node-postal 1.1.1, a Node.js 16 Docker image does _not_ correctly build libpostal, but with 1.1.2 the node-postal module is built and works correctly.

While our version range specifier means that node-postal 1.1.2 would have been brought in, it seems worth it to explicitly require it as we move towards Node.js 16 support everywhere.