### PR TITLE
downloads: improve logger messages

### DIFF
--- a/script/js/update_tiger.js
+++ b/script/js/update_tiger.js
@@ -51,9 +51,8 @@ function download(state, callback) {
       downloadFilteredFiles.bind(null, context)
     ],
     (err) => {
-      if (err) {
-        logger.error(err);
-      }
+      if (err) { logger.error(err); }
+      else { logger.info(`downloads complete`); }
       callback(err);
     });
 }
@@ -74,7 +73,7 @@ function getFilteredFileList(context, callback) {
   }
   adapter.list(`tl_2021_${filter}*.zip`, (err, files) => {
     if (err) { return callback(err); }
-    logger.info(`Queuing ${files.length} downloads`);
+    logger.debug(`queuing ${files.length} downloads`);
     context.files = files;
     callback();
   });
@@ -97,9 +96,9 @@ function downloadFile(context, filename, callback) {
   const localFile = path.join(context.downloadsDir, filename);
 
   adapter.get(filename, localFile, (err) => {
-    logger.info(`Downloading ${filename}`);
+    logger.debug(`downloading ${filename}`);
     if (err) { return callback(err); }
-    logger.debug(`Downloaded ${filename}`);
+    logger.info(`downloaded ${filename}`);
     callback();
   });
 }


### PR DESCRIPTION
the current log output when downloading TIGER files is very verbose and at the same time not super informative

```
info: [interpolation(TIGER)] Queuing 1 downloads
info: [interpolation(TIGER)] Downloading tl_2021_41051_addrfeat.zip
info: [interpolation(TIGER)] Queuing 1 downloads
info: [interpolation(TIGER)] Downloading tl_2021_41005_addrfeat.zip
info: [interpolation(TIGER)] Queuing 1 downloads
info: [interpolation(TIGER)] Downloading tl_2021_41071_addrfeat.zip
info: [interpolation(TIGER)] Queuing 1 downloads
info: [interpolation(TIGER)] Downloading tl_2021_41047_addrfeat.zip
info: [interpolation(TIGER)] Queuing 1 downloads
info: [interpolation(TIGER)] Downloading tl_2021_41053_addrfeat.zip
info: [interpolation(TIGER)] Queuing 1 downloads
info: [interpolation(TIGER)] Downloading tl_2021_53011_addrfeat.zip
```

this PR changes a few things:
- the 'Queuing 1 downloads' line is fairly redundant, I moved it to the `debug` log level
- the 'Downloading' and 'Downloaded' lines are swapped, so you get the 'downloaded' at the regular `info` log level
- a completion log line is printed as per other downloaders
- messages are lowercased (personal preference but IMO it looks better)