### PR TITLE
downloads: improve logger completion message

### DIFF
--- a/script/js/update_tiger.js
+++ b/script/js/update_tiger.js
@@ -33,6 +33,8 @@ async.eachSeries(STATES, download, (err)=>{
   if (err) {
     logger.error(err);
     process.exit(1);
+  } else {
+    logger.info(`downloads complete`);
   }
 });
 
@@ -52,7 +54,6 @@ function download(state, callback) {
     ],
     (err) => {
       if (err) { logger.error(err); }
-      else { logger.info(`downloads complete`); }
       callback(err);
     });
 }


### PR DESCRIPTION
following on from https://github.com/pelias/interpolation/pull/286 the completion message is still too verbose:

```
Creating pelias_interpolation_run ... done
info: [interpolation(TIGER)] downloaded tl_2021_41067_addrfeat.zip
info: [interpolation(TIGER)] downloads complete
info: [interpolation(TIGER)] downloaded tl_2021_41051_addrfeat.zip
info: [interpolation(TIGER)] downloads complete
info: [interpolation(TIGER)] downloaded tl_2021_41005_addrfeat.zip
info: [interpolation(TIGER)] downloads complete
info: [interpolation(TIGER)] downloaded tl_2021_41071_addrfeat.zip
info: [interpolation(TIGER)] downloads complete
info: [interpolation(TIGER)] downloaded tl_2021_41047_addrfeat.zip
info: [interpolation(TIGER)] downloads complete
info: [interpolation(TIGER)] downloaded tl_2021_41053_addrfeat.zip
info: [interpolation(TIGER)] downloads complete
info: [interpolation(TIGER)] downloaded tl_2021_53011_addrfeat.zip
info: [interpolation(TIGER)] downloads complete
```