### PR TITLE
CI: Update GitHub Actions config for uniformity

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -1,0 +1,28 @@
+name: Unit Tests
+on: workflow_call
+jobs:
+  unit-tests:
+    runs-on: '${{ matrix.os }}'
+    strategy:
+      matrix:
+        os:
+          - ${{ vars.UBUNTU_VERSION }}
+        node-version:
+          - 12.x
+          - 14.x
+          - 16.x
+    steps:
+      - uses: actions/checkout@v2
+      - name: 'Install node.js ${{ matrix.node-version }}'
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: '${{ matrix.node-version }}'
+      - name: Install dependencies
+        run: |
+          sudo add-apt-repository -y ppa:ubuntugis/ppa
+          sudo apt-get update -q
+          sudo apt-get install -y proj-bin gdal-bin
+      - name: Run unit tests
+        run: |
+          npm install
+          npm run ci

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,7 @@
+name: Continuous Integration
+on: pull_request
+jobs:
+  unit-tests:
+    # only run this job for forks
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    uses: ./.github/workflows/_test.yml

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,34 +2,11 @@ name: Continuous Integration
 on: push
 jobs:
   unit-tests:
-    runs-on: '${{ matrix.os }}'
-    strategy:
-      matrix:
-        os:
-          - ubuntu-20.04
-        node-version:
-          - 12.x
-          - 14.x
-          - 16.x
-    steps:
-      - uses: actions/checkout@v2
-      - name: 'Install node.js ${{ matrix.node-version }}'
-        uses: actions/setup-node@v2-beta
-        with:
-          node-version: '${{ matrix.node-version }}'
-      - name: Install dependencies
-        run: |
-          sudo add-apt-repository -y ppa:ubuntugis/ppa
-          sudo apt-get update -q
-          sudo apt-get install -y proj-bin gdal-bin
-      - name: Run unit tests
-        run: |
-          npm install
-          npm run ci
+    uses: ./.github/workflows/_test.yml
   npm-publish:
     needs: unit-tests
-    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-    runs-on: ubuntu-20.04
+    if: github.ref == 'refs/heads/master' && needs.unit-tests.result == 'success'
+    runs-on: ${{ vars.UBUNTU_VERSION }}
     steps:
       - uses: actions/checkout@v2
       - name: Install Node.js
@@ -49,7 +26,7 @@ jobs:
     # note: github actions won't run a job if you don't call one of the status check functions, so `always()` is called since it evalutes to `true`
     if: ${{ always() && needs.unit-tests.result == 'success' && (needs.npm-publish.result == 'success' || needs.npm-publish.result == 'skipped') }}
     needs: [unit-tests, npm-publish]
-    runs-on: ubuntu-20.04
+    runs-on: ${{ vars.UBUNTU_VERSION }}
     steps:
       - uses: actions/checkout@v2
       - name: Build Docker images


### PR DESCRIPTION
This updates CI configuration for this repo with the following changes:
- the core configuration for running unit tests is moved to _test.yml so it can be shared
- a new pull request workflow is added that only runs on external forks, and runs unit tests
- Ubuntu versions are now pulled from a GitHub Actions variable (see https://github.com/pelias/pelias/issues/951)

Sidenote: This is one of very few Pelias repos that cannot use exactly the same GitHub Actions config as others. There is a small bit to install dependencies like `gdal` that is different. Perhaps we should extract that into a bash script and add something to our standard CI template.