### PR TITLE
CI: drop EOL Node.js versions 12, 14, 16

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -8,9 +8,6 @@ jobs:
         os:
           - ${{ vars.UBUNTU_VERSION }}
         node-version:
-          - 12.x
-          - 14.x
-          - 16.x
           - 18.x
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
We can't add Node.js 20 or 22 yet until node-postal supports it and we use a compatible version of better-sqlite3

https://github.com/pelias/pelias/issues/950
