### PR TITLE
Update CI to conform to a standard template and test all supported, non-EOL LTS Node.js releases

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -8,9 +8,6 @@ jobs:
         os:
           - ubuntu-22.04
         node-version:
-          - 12.x
-          - 14.x
-          - 16.x
           - 18.x
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ${{ vars.UBUNTU_VERSION }}
+          - ubuntu-22.04
         node-version:
           - 12.x
           - 14.x

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -7,8 +7,7 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-        node-version:
-          - 18.x
+        node-version: [ 18.x ]
     steps:
       - uses: actions/checkout@v4
       - name: 'Install node.js ${{ matrix.node-version }}'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,7 +6,7 @@ jobs:
   npm-publish:
     needs: unit-tests
     if: github.ref == 'refs/heads/master' && needs.unit-tests.result == 'success'
-    runs-on: ${{ vars.UBUNTU_VERSION }}
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Install Node.js
@@ -26,7 +26,7 @@ jobs:
     # note: github actions won't run a job if you don't call one of the status check functions, so `always()` is called since it evalutes to `true`
     if: ${{ always() && needs.unit-tests.result == 'success' && (needs.npm-publish.result == 'success' || needs.npm-publish.result == 'skipped') }}
     needs: [unit-tests, npm-publish]
-    runs-on: ${{ vars.UBUNTU_VERSION }}
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Build Docker images


### PR DESCRIPTION
This PR includes a bunch of commits made by a script that standardizes as much as possible our CI config across all repositories.

Along the way it also ensures we test all Node.js versions that are an LTS release, not EOL, and currently work with this repository. Any Github Actions that were out of date or used old Node.js versions (checkout and setup-node @v2) are also updated.

For the interpolation repository that means Node.js 18 only, as we have to upgrade node-postal to v1.20 for Node.js 20 support. Similarly we need to update better-sqlite3 for Node.js 22 support.

Also, the CI OS version is now hardcoded to `ubuntu-22.04`. We fooled around with an organization wide CI variable to configure that, but it broke CI in forks and doesn't really help us much, so it's now undone.

If there are any other differences in Github Actions Workflow files, they are also now removed by using a standard template.

Finally, because this repository has a Dockerfile and we just [updated the Docker baseimage to support Node.js 18](https://github.com/pelias/docker-baseimage/pull/29), there is an empty commit to trigger a new major version release.

Connects https://github.com/pelias/pelias/issues/950
Connects https://github.com/pelias/pelias/issues/951