### PR TITLE
CI: Drop Node.js 18 from CI

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -7,7 +7,7 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-        node-version: [ 18.x, 20.x, 22.x ]
+        node-version: [ 20.x, 22.x ]
     steps:
       - uses: actions/checkout@v4
       - name: 'Install node.js ${{ matrix.node-version }}'


### PR DESCRIPTION
This repo's tests are already failing on Node.js 18 due to the transitive dependency `undici` brought in via `cherrio`.

Connects https://github.com/pelias/pelias/issues/985