### PR TITLE
Upgrade better-sqlite3 to v12.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@mapbox/polyline": "^1.0.0",
     "async": "^3.1.0",
-    "better-sqlite3": "^11.5.0",
+    "better-sqlite3": "^12.2.0",
     "cheerio": "^1.0.0-rc.3",
     "cli-table3": "^0.6.0",
     "csv-parse": "^4.4.6",


### PR DESCRIPTION
This helps with easier installation on Mac and other ARM platforms when using newer Node.js versions.

