### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-22.04
+          - ubuntu-24.04
         node-version: [ 20.x, 22.x, 24.x ]
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -16,7 +16,6 @@ jobs:
           node-version: '${{ matrix.node-version }}'
       - name: Install dependencies
         run: |
-          sudo add-apt-repository -y ppa:ubuntugis/ppa
           sudo apt-get update -q
           sudo apt-get install -y proj-bin gdal-bin
       - name: Run unit tests

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -9,9 +9,9 @@ jobs:
           - ubuntu-22.04
         node-version: [ 20.x, 22.x, 24.x ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: 'Install node.js ${{ matrix.node-version }}'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '${{ matrix.node-version }}'
       - name: Install dependencies

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,7 +6,7 @@ jobs:
   npm-publish:
     needs: unit-tests
     if: github.ref == 'refs/heads/master' && needs.unit-tests.result == 'success'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
       - name: Install Node.js
@@ -26,7 +26,7 @@ jobs:
     # note: github actions won't run a job if you don't call one of the status check functions, so `always()` is called since it evalutes to `true`
     if: ${{ always() && needs.unit-tests.result == 'success' && (needs.npm-publish.result == 'success' || needs.npm-publish.result == 'skipped') }}
     needs: [unit-tests, npm-publish]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
       - name: Build Docker images

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,9 +8,9 @@ jobs:
     if: github.ref == 'refs/heads/master' && needs.unit-tests.result == 'success'
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20.x
       - name: Run semantic-release
@@ -28,7 +28,7 @@ jobs:
     needs: [unit-tests, npm-publish]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build Docker images
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
This updates our CI to build using Ubuntu 24, and the latest Github actions like checkout@v6 and setup-node@v6, removing deprecation warnings.

In Ubuntu 24, proj and gdal are available in the default Ubuntu repositories, so conveniently we can remove a line of custom setup for this repo that sets up the UbuntuGIS PPA.