### PR TITLE
Use ci-setup script to avoid custom Github Actions code

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -14,11 +14,8 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '${{ matrix.node-version }}'
-      - name: Install dependencies
-        run: |
-          sudo apt-get update -q
-          sudo apt-get install -y proj-bin gdal-bin
       - name: Run unit tests
         run: |
+          [[ -f ./bin/ci-setup ]] && ./bin/ci-setup
           npm install
           npm run ci

--- a/bin/ci-setup
+++ b/bin/ci-setup
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -o pipefail
+
+sudo apt-get update -q
+sudo apt-get install -y gdal-bin


### PR DESCRIPTION
Some time ago we created the `ci-setup` binary convention for Pelias repos that need some custom setup, for example in the spatial repo.

We use it here now and can then ensure that the `.github` files are all otherwise identical to most of our repos, easing future maintenance

Note: we can drop the proj-bin dependency entirely here, its no longer used.